### PR TITLE
Print Targets

### DIFF
--- a/pretext/build.py
+++ b/pretext/build.py
@@ -1,11 +1,10 @@
 from lxml import etree as ET
 import logging
 import os
-import shutil
 import sys
 import pathlib
 
-from . import static, utils
+from . import utils
 from .static.pretext import pretext as core
 
 # Get access to logger

--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -38,7 +38,7 @@ def main(targets):
         verbosity = 1
     core.set_verbosity(verbosity)
     if targets:
-        Project().list_target_names()
+        Project().print_target_names()
         return
     if utils.project_path() is not None:
         log.info(f"PreTeXt project found in `{utils.project_path()}`.")

--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -1,18 +1,12 @@
 import click
 import click_logging
-import json
-from lxml import etree as ET
 import logging
-import sys
 import shutil
-import socket
-import subprocess
 import os, zipfile, requests, io
 import tempfile, shutil
-import git
+
 from . import utils, static
 from . import version as cli_version
-from . import build as builder
 from .static.pretext import pretext as core
 from .project import Target,Project
 
@@ -233,13 +227,3 @@ def publish(target):
     target_name = target
     project = Project()
     project.publish(target_name)
-
-## pretext debug
-# @main.command(short_help="just for testing")
-# def debug():
-#     import os
-#     from . import static, document, utils
-#     log.info("This is just for debugging and testing new features.")
-#     static_dir = os.path.dirname(static.__file__)
-#     xslfile = os.path.join(static_dir, 'xsl', 'pretext-html.xsl')
-#     print(xslfile)

--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -19,11 +19,12 @@ def raise_cli_error(message):
 
 
 #  Click command-line interface
-@click.group()
+@click.group(invoke_without_command=True)
 # Allow a verbosity command:
 @click_logging.simple_verbosity_option(log, help="Sets the severity of warnings: DEBUG for all; CRITICAL for almost none.  ERROR, WARNING, or INFO (default) are also options.")
 @click.version_option(cli_version(),message=cli_version())
-def main():
+@click.option('-t', '--targets', is_flag=True, help='Display list of build/view "targets" available in the project manifest.')
+def main(targets):
     """
     Command line tools for quickly creating, authoring, and building
     PreTeXt documents.
@@ -36,6 +37,9 @@ def main():
     else:
         verbosity = 1
     core.set_verbosity(verbosity)
+    if targets:
+        Project().list_target_names()
+        return
     if utils.project_path() is not None:
         log.info(f"PreTeXt project found in `{utils.project_path()}`.")
         os.chdir(utils.project_path())

--- a/pretext/project.py
+++ b/pretext/project.py
@@ -1,5 +1,5 @@
 from lxml import etree as ET
-import os, sys, shutil
+import os, shutil
 import logging
 import git
 from . import static, utils

--- a/pretext/project.py
+++ b/pretext/project.py
@@ -149,13 +149,12 @@ class Project():
     def targets(self):
         return [
             Target(xml_element=target_element,project_path=self.__project_path)
-            for target_element in xml_element().xpath("targets/target")
+            for target_element in self.xml_element().xpath("targets/target")
         ]
     
     def list_target_names(self):
-        for target in self.xml_element().xpath('targets/target'):
-            if len(target.xpath('@name'))>0:
-                print(''.join(target.xpath('@name')))
+        for target in self.targets():
+            print(target.name())
 
     def target(self,name=None):
         if name is None:

--- a/pretext/project.py
+++ b/pretext/project.py
@@ -151,6 +151,11 @@ class Project():
             Target(xml_element=target_element,project_path=self.__project_path)
             for target_element in xml_element().xpath("targets/target")
         ]
+    
+    def list_target_names(self):
+        for target in self.xml_element().xpath('targets/target'):
+            if len(target.xpath('@name'))>0:
+                print(''.join(target.xpath('@name')))
 
     def target(self,name=None):
         if name is None:

--- a/pretext/project.py
+++ b/pretext/project.py
@@ -152,7 +152,7 @@ class Project():
             for target_element in self.xml_element().xpath("targets/target")
         ]
     
-    def list_target_names(self):
+    def print_target_names(self):
         for target in self.targets():
             print(target.name())
 

--- a/pretext/utils.py
+++ b/pretext/utils.py
@@ -10,7 +10,7 @@ import threading
 import watchdog.events, watchdog.observers, time
 from lxml import etree as ET
 
-from . import static, build
+from . import static
 
 # Get access to logger
 log = logging.getLogger('ptxlogger')


### PR DESCRIPTION
Two changes:
- Removed imports that never got used
- Implemented --targets option to print the names of targets in the project manifest (useful for the vs-code extension).

Not sure if I did this is a object-oriented enough way.  There was a method "targets" for Project(), but perhaps that is broken?  (The `xml_element` in the `for` statement is not defined?)

This would close #127.  