### PR TITLE
Working static.path and static.core_xsl functions

### DIFF
--- a/pretext/__init__.py
+++ b/pretext/__init__.py
@@ -1,5 +1,5 @@
 from . import static
 
 def version():
-    with open(static.filepath('VERSION'), 'r') as version_file:
+    with open(static.path('VERSION'), 'r') as version_file:
         return version_file.read().strip()

--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -65,12 +65,11 @@ def new(template,directory,url_template):
         log.warning(f"No new project will be generated.")
         return
     log.info(f"Generating new PreTeXt project in `{directory_fullpath}` using `{template}` template.")
-    static_dir = os.path.dirname(static.__file__)
     if url_template is not None:
         r = requests.get(url_template)
         archive = zipfile.ZipFile(io.BytesIO(r.content))
     else:
-        template_path = os.path.join(static_dir, 'templates', f'{template}.zip')
+        template_path = static.path('templates', f'{template}.zip')
         archive = zipfile.ZipFile(template_path)
     # find (first) project.ptx to use as root of template
     filenames = [os.path.basename(filepath) for filepath in archive.namelist()]
@@ -98,8 +97,7 @@ def init():
         log.warning(f"No project manifest will be generated.")
         return
     log.info(f"Generating new PreTeXt manifest in `{directory_fullpath}`.")
-    static_dir = os.path.dirname(static.__file__)
-    manifest_path = os.path.join(static_dir, 'templates', 'project.ptx')
+    manifest_path = static.path('templates', 'project.ptx')
     project_ptx_path = os.path.join(directory_fullpath,"project.ptx")
     shutil.copyfile(manifest_path,project_ptx_path)
     log.info(f"Success! Open `{project_ptx_path}` to edit your manifest.")

--- a/pretext/project.py
+++ b/pretext/project.py
@@ -22,14 +22,11 @@ class Target():
         if project_path is None:
             project_path = os.getcwd()
         if xml_element is None:
-                static_dir = os.path.dirname(static.__file__)
-                template_xml = os.path.join(static_dir,"templates","project.ptx")
+                template_xml = static.path("templates","project.ptx")
                 xml_element = ET.parse(template_xml).getroot().find("targets/target")
-                publication = os.path.join(static_dir,"templates","project.ptx")
+                publication_path = static.path("templates","publication.ptx")
                 for pub_ele in xml_element.xpath("publication"):
-                    xml_element.remove(pub_ele)
-                pub_ele = ET.SubElement(xml_element,"publication")
-                pub_ele.text = publication
+                    pub_ele.text = publication_path
         if xml_element.tag != "target":
             raise ValueError("xml_element must have tag `target` as root")
         # construct self.xml_element
@@ -128,8 +125,7 @@ class Project():
             if utils.project_path() is not None:
                 xml_element = ET.parse(os.path.join(utils.project_path(),"project.ptx")).getroot()
             else:
-                static_dir = os.path.dirname(static.__file__)
-                template_xml = os.path.join(static_dir,"templates","project.ptx")
+                template_xml = static.path("templates","project.ptx")
                 xml_element = ET.parse(template_xml).getroot()
         else:
             if xml_element.tag != "project":

--- a/pretext/static/__init__.py
+++ b/pretext/static/__init__.py
@@ -1,10 +1,25 @@
-import importlib.resources as pkg_resources
+# eventually we need to refactor ala
+#   https://docs.python.org/3/library/importlib.html#module-importlib.resources
+# But for practical purposes the CLI is realized as actual files in the filesystem, so we'll
+# assume this for now
+#   import importlib.resources as pkg_resources
 
+import os
+from lxml import etree as ET
+from . import __file__ as STATIC_PATH
 
-def filepath(filename):
+def path(*args):
     """
-    Returns path to files in the static folder of the distribution.
+    Returns absolute path to files in the static folder of the distribution.
     """
-    with pkg_resources.path(__name__, filename) as p:
-        static_file = str(p.resolve())
-    return static_file
+    return os.path.abspath(os.path.join(
+        os.path.dirname(STATIC_PATH),
+        *args
+    ))
+
+def core_xsl(*args,as_path=False):
+    xsl_path = path("xsl",*args)
+    if as_path:
+        return xsl_path
+    else:
+        return ET.parse(xsl_path)

--- a/pretext/utils.py
+++ b/pretext/utils.py
@@ -65,8 +65,7 @@ def project_path(dirpath=os.getcwd()):
 
 def project_xml(dirpath=os.getcwd()):
     if project_path(dirpath) is None:
-        static_dir = os.path.dirname(static.__file__)
-        project_manifest = os.path.join(static_dir, 'templates', 'project.ptx')
+        project_manifest = static.path('templates','project.ptx')
     else:
         project_manifest = os.path.join(project_path(dirpath), 'project.ptx')
     return ET.parse(project_manifest)
@@ -119,8 +118,7 @@ def xml_syntax_is_valid(xmlfile):
 
 def xml_schema_is_valid(xmlfile):
     #get path to RelaxNG schema file:
-    static_dir = os.path.dirname(static.__file__)
-    schemarngfile = os.path.join(static_dir, 'schema', 'pretext.rng')
+    schemarngfile = static.path('schema','pretext.rng')
 
     # Open schemafile for validation:
     relaxng = ET.RelaxNG(file=schemarngfile)


### PR DESCRIPTION
Note well https://github.com/PreTeXtBook/pretext-cli/compare/expose-static?expand=1#diff-d4e531fb4b8157014d5ea3c8558800fcf7b7d16d2bc4f0382b000b8d03572499R1 - so far no one has reported an issue stemming from a system where our package is stored as e.g. a zip rather than actual files in the filesystem, but we should fix this in the future. (Perhaps by dumping static resources into a temporary directory when something is requested.)

In addition to removing some boilerplate, `static.core_xsl` will help reduce complexity of scripting like https://github.com/StevenClontz/cal1-tbil-2021/blob/main/build_html_with_slides.py