### PR TITLE
utility to expand @pretext-href to href in XSL files, closes #139

### DIFF
--- a/pretext/utils.py
+++ b/pretext/utils.py
@@ -223,3 +223,10 @@ NSMAP = {
 }
 def nstag(prefix,suffix):
     return "{" + NSMAP[prefix] + "}" + suffix
+
+def expand_pretext_href(lxml_element):
+    '''
+    Expands @pretext-href attributes to point to the distributed xsl directory.
+    '''
+    for ele in lxml_element.xpath('//*[@pretext-href]'):
+        ele.set('href',str(static.core_xsl(ele.get('pretext-href'),as_path=True)))


### PR DESCRIPTION
We don't use this utility internally but I anticipate we will to support custom XSL in the future. (And it's useful for scripting with custom XSL in the meantime.)