### PR TITLE
fix path URI issue with xsl:include on Windows

### DIFF
--- a/pretext/build.py
+++ b/pretext/build.py
@@ -2,8 +2,6 @@ from re import T
 from lxml import etree as ET
 import logging
 import os
-import sys
-import pathlib
 
 from . import utils
 from .static.pretext import pretext as core
@@ -11,28 +9,23 @@ from .static.pretext import pretext as core
 # Get access to logger
 log = logging.getLogger('ptxlogger')
 
-def linux_path(path):
-    # hack to make core ptx happy
-    p = pathlib.Path(path)
-    return p.as_posix()
-
 def html(ptxfile,pub_file,output,stringparams,custom_xsl):
     utils.ensure_directory(output)
     log.info(f"\nNow building HTML into {output}\n")
     with utils.working_directory("."):
-        core.html(ptxfile, linux_path(pub_file), stringparams, custom_xsl, output)
+        core.html(ptxfile, utils.linux_path(pub_file), stringparams, custom_xsl, output)
 
 def latex(ptxfile,pub_file,output,stringparams,custom_xsl):
     utils.ensure_directory(output)
     log.info(f"\nNow building LaTeX into {output}\n")
     with utils.working_directory("."):
-        core.latex(ptxfile, linux_path(pub_file), stringparams, custom_xsl, None, output)
+        core.latex(ptxfile, utils.linux_path(pub_file), stringparams, custom_xsl, None, output)
 
 def pdf(ptxfile,pub_file,output,stringparams,custom_xsl):
     utils.ensure_directory(output)
     log.info(f"\nNow building LaTeX into {output}\n")
     with utils.working_directory("."):
-        core.pdf(ptxfile, linux_path(pub_file), stringparams, custom_xsl,
+        core.pdf(ptxfile, utils.linux_path(pub_file), stringparams, custom_xsl,
                  None, dest_dir=output)
 
 # Function to build diagrams/images contained in source.
@@ -67,7 +60,7 @@ def diagrams(ptxfile, pub_file, output, params, target_format, diagrams_format):
         log.info('Now generating sageplot images\n\n')
         with utils.working_directory("."):
             core.sage_conversion(
-                xml_source=ptxfile, pub_file=linux_path(pub_file), stringparams=params,
+                xml_source=ptxfile, pub_file=utils.linux_path(pub_file), stringparams=params,
                 xmlid_root=None, dest_dir=image_output, outformat=formats[target_format]['sageplot'])
     if len(source_xml.xpath("/pretext/*[not(docinfo)]//asymptote")) > 0 and formats[target_format]['asymptote']:
         image_output = os.path.abspath(
@@ -76,7 +69,7 @@ def diagrams(ptxfile, pub_file, output, params, target_format, diagrams_format):
         log.info('Now generating asymptote images\n\n')
         with utils.working_directory("."):
             core.asymptote_conversion(
-                xml_source=ptxfile, pub_file=linux_path(pub_file), stringparams=params,
+                xml_source=ptxfile, pub_file=utils.linux_path(pub_file), stringparams=params,
                 xmlid_root=None, dest_dir=image_output, outformat=formats[target_format]['asymptote'], method='server')
     if len(source_xml.xpath("/pretext/*[not(docinfo)]//interactive[not(@preview)]"))> 0:
         image_output = os.path.abspath(
@@ -85,7 +78,7 @@ def diagrams(ptxfile, pub_file, output, params, target_format, diagrams_format):
         log.info('Now generating preview images for interactives\n\n')
         with utils.working_directory("."):
             core.preview_images(
-                xml_source=ptxfile, pub_file=linux_path(pub_file), stringparams=params,
+                xml_source=ptxfile, pub_file=utils.linux_path(pub_file), stringparams=params,
                 xmlid_root=None, dest_dir=image_output)
     if len(source_xml.xpath("/pretext/*[not(docinfo)]//video[@youtube]")) > 0:
         image_output = os.path.abspath(
@@ -94,7 +87,7 @@ def diagrams(ptxfile, pub_file, output, params, target_format, diagrams_format):
         log.info('Now generating youtube previews\n\n')
         with utils.working_directory("."):
             core.youtube_thumbnail(
-                xml_source=ptxfile, pub_file=linux_path(pub_file), stringparams=params,
+                xml_source=ptxfile, pub_file=utils.linux_path(pub_file), stringparams=params,
                 xmlid_root=None, dest_dir=image_output)
 
 

--- a/pretext/utils.py
+++ b/pretext/utils.py
@@ -4,6 +4,7 @@ import json
 from contextlib import contextmanager
 from http.server import SimpleHTTPRequestHandler
 import shutil
+import pathlib
 import socketserver
 import socket
 import logging
@@ -33,6 +34,10 @@ def working_directory(path):
     finally:
         os.chdir(current_directory)
 
+def linux_path(path):
+    # hack to make core ptx and xsl:import happy
+    p = pathlib.Path(path)
+    return p.as_posix()
 
 def ensure_directory(path):
     """
@@ -232,7 +237,7 @@ def expand_pretext_href(lxml_element):
     Expands @pretext-href attributes to point to the distributed xsl directory.
     '''
     for ele in lxml_element.xpath('//*[@pretext-href]'):
-        ele.set('href',str(static.core_xsl(ele.get('pretext-href'),as_path=True)))
+        ele.set('href',str(linux_path(static.core_xsl(ele.get('pretext-href'),as_path=True))))
 
 def copy_fix_xsl(xsl_path, output_dir):
     xsl_dir = os.path.abspath(os.path.dirname(xsl_path))


### PR DESCRIPTION
I think this takes care of it, but for some reason I can't pip install from the remote for some reason (`UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 1663: character maps to <undefined>`).  Can you build RC1 after accepting this and I can test again, please?