### PR TITLE
Prompt to go view HTML in browser

### DIFF
--- a/pretext/utils.py
+++ b/pretext/utils.py
@@ -203,7 +203,7 @@ def serve_forever(directory,access="private",port=8000):
                 looking_for_port = False
                 url = url_for_access(access,port)
                 log.info(f"Server started at {url}")
-                log.info(f"(In a web browser, you may visit {url} to view HTML output.)")
+                log.info(f"(In a web browser, you may visit {url} to view output.)")
                 log.info("Use [Ctrl]+[C] to halt the server.\n")
                 httpd.serve_forever()
         except OSError:

--- a/pretext/utils.py
+++ b/pretext/utils.py
@@ -202,7 +202,8 @@ def serve_forever(directory,access="private",port=8000):
             with TCPServer((binding, port), RequestHandler) as httpd:
                 looking_for_port = False
                 url = url_for_access(access,port)
-                log.info(f"Server started at {url}\n")
+                log.info(f"Server started at {url}")
+                log.info(f"(In a web browser, you may visit {url} to view HTML output.)")
                 log.info("Use [Ctrl]+[C] to halt the server.\n")
                 httpd.serve_forever()
         except OSError:


### PR DESCRIPTION
As a CLI newb, I did not initially know what to do next after `pretext view html`. A message like this is one would orient me.

This is the same as #203, but now from a branch in my own fork.