### PR TITLE
remove @webwork-problems

### DIFF
--- a/pretext/project.py
+++ b/pretext/project.py
@@ -123,14 +123,6 @@ class Target():
         rel_dir = dir_ele.get("generated")
         return os.path.join(self.source_dir(),rel_dir)
 
-    def webwork_representations_path(self):
-        dir_ele = self.publication_xml().find("source[@webwork-problems]")
-        if dir_ele is None:
-            log.debug("Publication file does not specify webwork-representation.ptx file")
-            return None
-        rel_dir = dir_ele.get("webwork-problems")
-        return os.path.join(self.source_dir(),rel_dir)
-
     def output_dir(self):
         return os.path.abspath(os.path.join(self.__project_path,self.xml_element().find("output-dir").text.strip()))
 
@@ -233,12 +225,6 @@ class Project():
         target = self.target(target_name)
         utils.ensure_directory(target.external_dir())
         utils.ensure_directory(target.generated_dir())
-        # Check for WeBWorK but not webwork-representations file:
-        if len(target.source_xml().xpath('//webwork'))>0:
-            if target.webwork_representations_path() is None:
-                log.warning(f'Your source contains WeBWorK exercises but you do not have a "webwork-representations" file specified in your publication file.  Modify your publication file and run `pretext build -w`.')
-            elif not os.path.isfile(target.webwork_representations_path()):
-                log.warning(f'Your source contains WeBWorK exercises the path to the "webwork-representations.ptx" file in your publication file does not point to a file. Run `pretext build -w` or modify your publication file.')
         # refuse to clean if output is not a subdirectory of the working directory or contains source/publication
         if clean:
             if Path(self.__project_path) not in Path(target.output_dir()).parents:
@@ -274,7 +260,7 @@ class Project():
                 log.warning(f"No server name, {root_cause}.")
                 log.warning(f"Using default {server_url}")
             builder.webwork(target.source(), target.publication(), webwork_output, target.stringparams(), server_url)
-        elif len(target.source_xml().xpath('//webwork')) > 0:
+        elif len(target.source_xml().xpath('//webwork[node()|@*]')) > 0:
             log.warning(
                 "The source has WeBWorK exercises, but you are not re(processing) these.  Run `pretext build` with the `-w` flag if updates are needed.")
         if diagrams:

--- a/templates/article/publication/publication.ptx
+++ b/templates/article/publication/publication.ptx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <publication>
     <!-- directories are relative to the main source PreTeXt file -->
-    <source webwork-problems="../generated-assets/webwork/webwork-representations.ptx">
+    <source>
         <directories external="../assets" generated="../generated-assets"/>
     </source>
 </publication>

--- a/templates/book/publication/publication.ptx
+++ b/templates/book/publication/publication.ptx
@@ -12,7 +12,7 @@
   <!-- Set where external assets and generated assets will be   -->
   <!-- stored or created.  Directories are relative to the main -->
   <!-- source PreTeXt file                                      -->
-  <source webwork-problems="../generated-assets/webwork/webwork-representations.ptx">
+  <source>
     <directories external="../assets" generated="../generated-assets"/>
   </source>
 

--- a/templates/book/source/ex_firstch.ptx
+++ b/templates/book/source/ex_firstch.ptx
@@ -34,9 +34,8 @@
     </hint>
   </exercise>
   
-  <!-- For an example of WeBWorK, uncomment the next exercise and        -->
-  <!-- run `pretext build html -w`.  You must also specify where         -->
-  <!-- the "webwork-representations.ptx" file is in the publication file -->
+  <!-- For an example of WeBWorK, uncomment the next -->
+  <!-- exercise and run `pretext build html -w`.     -->
   <!-- <exercise>
     <webwork xml:id="webwork-add-numbers">
       <description>

--- a/templates/hello/publication/publication.ptx
+++ b/templates/hello/publication/publication.ptx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <publication>
     <!-- directories are relative to the main source PreTeXt file -->
-    <source webwork-problems="../generated-assets/webwork/webwork-representations.ptx">
+    <source>
         <directories external="../assets" generated="../generated-assets"/>
     </source>
 </publication>

--- a/templates/publication.ptx
+++ b/templates/publication.ptx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <publication>
     <!-- directories are relative to the main source PreTeXt file -->
-    <source webwork-problems="../generated-assets/webwork/webwork-representations.ptx">
+    <source>
         <directories external="../assets" generated="../generated-assets"/>
     </source>
 </publication>


### PR DESCRIPTION
I haven't tested that this actually works :)  I'm not sure how I do that. Maybe I can get an orientation next Friday? I have the CLI installed, but I'm not sure how to run anything from my pretext-cli repo/branch.

Anyway, at the present time, `source/@webwork-problems` is deprecated. Instead it all should just work using the `generated` folder. So I removed anything having to do with `source/@webwork-problems` and pretext itself should do the right thing if the publisher file has `@generated`.

But yeah, someone should test this. If you `pretext init` in `pretext/examples/webwork/minimal/` and you change the `project.ptx` there to use `<source>mini.xml</source>` and use `<publication>publication.xml</publication>` then you can try this out.

I think there are still some misleading/incorrect bug/warning messages coming through, but not form the CLI. Exploring those is phase 2 after this is resolved.

Also I changed a `//webwork` to `//webwork[node()|@*] so that search skips over empty `<webwork/>` elements, which are not webwork exercises, but rather a generator making "WeBWorK".