### PR TITLE
Copy all files/subdirs that are peers of custom xsl

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,14 +193,14 @@ need to be rebuilt by each user when pulled from GitHub.
 
 The file `pretext/static/CORE_COMMIT` tracks the upstream
 commit of core PreTeXt XSL/Python code we're developing against
-(from `rbeezer/pretext`).
+(from `PreTeXtBook/pretext`).
 To grab these updates from upstream, run:
 
 ```
 python scripts/update_core.py
 ```
 
-If you instead want to point to a local copy of `rbeezer/pretext`,
+If you instead want to point to a local copy of `PreTeXtBook/pretext`,
 try this instead to set up symlinks:
 
 ```

--- a/README.md
+++ b/README.md
@@ -193,18 +193,18 @@ need to be rebuilt by each user when pulled from GitHub.
 
 The file `pretext/static/CORE_COMMIT` tracks the upstream
 commit of core PreTeXt XSL/Python code we're developing against
-(from `rbeezer/mathbook`).
+(from `rbeezer/pretext`).
 To grab these updates from upstream, run:
 
 ```
 python scripts/update_core.py
 ```
 
-If you instead want to point to a local copy of `rbeezer/mathbook`,
+If you instead want to point to a local copy of `rbeezer/pretext`,
 try this instead to set up symlinks:
 
 ```
-python scripts/simlink_core.py path/to/mathbook
+python scripts/symlink_core.py path/to/pretext
 ```
 
 Updates to `templates/` must be zipped and moved into
@@ -235,5 +235,5 @@ See [VERSIONING.md](VERSIONING.md).
 - [Oscar Levin](https://math.oscarlevin.com/)
 
 ### About PreTeXt
-The development of [PreTeXt's core](https://github.com/rbeezer/mathbook)
+The development of [PreTeXt's core](https://github.com/PreTeXtBook/pretext)
 is led by [Rob Beezer](http://buzzard.ups.edu/).

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -1,6 +1,6 @@
 import subprocess, os, shutil
 
-# grab verison number
+# grab version number
 with open("pretext/static/VERSION") as f:
     version = f.read().strip()
 

--- a/scripts/symlink_core.py
+++ b/scripts/symlink_core.py
@@ -15,4 +15,4 @@ for subdir in ['xsl','schema','pretext']:
     remove(link_path)
     os.symlink(original_path,link_path)
 
-print("Linked local pretext directory")
+print("Linked local core pretext directory")

--- a/scripts/symlink_core.py
+++ b/scripts/symlink_core.py
@@ -15,4 +15,4 @@ for subdir in ['xsl','schema','pretext']:
     remove(link_path)
     os.symlink(original_path,link_path)
 
-print("Linked local rbeezer/mathbook ")
+print("Linked local pretext directory")

--- a/scripts/update_core.py
+++ b/scripts/update_core.py
@@ -8,7 +8,7 @@ def remove(path):
     elif os.path.isdir(path):
         shutil.rmtree(path)  # remove dir and all contains
 
-# grab copy of necessary rbeezer/mathbook files from specified commit
+# grab copy of necessary PreTeXtBook/pretext files from specified commit
 with open("pretext/static/CORE_COMMIT","r") as commitfile:
     commit = commitfile.readline().strip()
 


### PR DESCRIPTION
This PR offers a partial solution to https://github.com/PreTeXtBook/pretext-cli/issues/213

At the moment, all peer `xsl` from a custom-specified xsl file is copied. However, no subdirectories or `xml` is copied. That means if you specify, for example, `pretext-html.xsl` from git master as your custom `xsl`, the `translations` subdirectory will not be copied. The result is many compile errors!

This PR
  1. Copies all peer subdirectories and files to a custom `xsl`. The files are not limited to the `xsl` extension
  2. Renames some references to `rbeezer/mathbook` to reference `pretext` (the current project name).