### PR TITLE
Improvements to deploy workflow

### DIFF
--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -135,6 +135,9 @@ def new(template,directory,url_template):
             archive.extract(filepath,path=tmpdirname)
         tmpsubdirname = os.path.join(tmpdirname,project_dir_path)
         shutil.copytree(tmpsubdirname,directory,dirs_exist_ok=True)
+    # generate requirements.txt
+    with open(os.path.join(directory_fullpath,"requirements.txt"),"w") as f:
+        f.write(f"pretextbook == {cli_version()}")
     log.info(f"Success! Open `{directory_fullpath}/source/main.ptx` to edit your document")
     log.info(f"Then try to `pretext build` and `pretext view` from within `{directory_fullpath}`.")
 
@@ -155,6 +158,8 @@ def init():
     project_manifest_path = os.path.abspath("project.ptx")
     log.info(f"Generating `{project_manifest_path}`.")
     shutil.copyfile(template_manifest_path,project_manifest_path)
+    with open("requirements.txt","w") as f:
+        f.write(f"pretextbook == {cli_version()}")
     log.info(f"Success! Open `{project_manifest_path}` to edit your project manifest.")
     log.info(f"Edit your <target/>s to point to your main PreTeXt source file.")
     project_pub_path = os.path.abspath(os.path.join("publication","publication.ptx"))

--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -138,6 +138,7 @@ def new(template,directory,url_template):
     log.info(f"Success! Open `{directory_fullpath}/source/main.ptx` to edit your document")
     log.info(f"Then try to `pretext build` and `pretext view` from within `{directory_fullpath}`.")
 
+
 # pretext init
 @main.command(short_help="Generates the project manifest for a PreTeXt project in the current directory.", 
     context_settings=CONTEXT_SETTINGS)
@@ -160,6 +161,7 @@ def init():
     if not os.path.isfile(project_pub_path):
         log.warning(f"Note that your publication file should be moved to `{project_pub_path}`, or")
         log.warning(f"`{project_manifest_path}` should be updated to the location of your publication file.")
+
 
 # pretext build
 @main.command(short_help="Build specified target", 
@@ -231,6 +233,7 @@ def build(target, format, source, output, stringparam, xsl, publication, webwork
         project = Project(xml_element=project.xml_element(),targets=[target])
     project.build(target_name,webwork,diagrams,diagrams_format,only_assets,clean)
 
+
 # pretext view
 @main.command(short_help="Preview specified target in your browser.", 
     context_settings=CONTEXT_SETTINGS)
@@ -289,8 +292,9 @@ def view(target,access,port,directory,watch,build):
     else:
         log.error(f"Target `{target_name}` could not be found.")
 
-# pretext publish
-@main.command(short_help="Publishes Git-managed project on GitHub Pages.", 
+
+# pretext deploy
+@main.command(short_help="Deploys Git-managed project to GitHub Pages.",
     context_settings=CONTEXT_SETTINGS)
 @click.argument('target', required=False)
 @click.option(
@@ -301,15 +305,36 @@ def view(target,access,port,directory,watch,build):
     help="""
     Customize message to leave on Git commit for source updates.
     """)
-def publish(target,commit_message):
+def deploy(target,commit_message):
     """
-    Automates HTML publication of [TARGET] on GitHub Pages to make
-    the built document available to the general public.
+    Automatically deploys most recent build of [TARGET] to GitHub Pages,
+    making it available to the general public.
     Requires that your project is under Git version control
-    properly configured with GitHub and GitHub Pages. Pubilshed
+    properly configured with GitHub and GitHub Pages. Deployed
     files will live in `docs` subdirectory of project.
     """
     target_name = target
     project = Project()
-    project.publish(target_name,commit_message)
+    project.deploy(target_name,commit_message)
 
+# pretext publish
+@main.command(short_help="DEPRECATED: use deploy",
+    context_settings=CONTEXT_SETTINGS)
+@click.argument('target', required=False)
+@click.option(
+    '-m',
+    '--commit-message',
+    default="Update to PreTeXt project source.",
+    show_default=True,
+    help="""
+    Customize message to leave on Git commit for source updates.
+    """)
+@click.pass_context
+def publish(ctx,target,commit_message):
+    """
+    DEPRECATED in favor of `deploy` command. Will be
+    removed in a future version.
+    """
+    log.warning("`pretext publish` command is DEPRECATED and will be removed soon.")
+    log.warning("Use `pretext deploy` next time.")
+    ctx.forward(deploy)

--- a/pretext/project.py
+++ b/pretext/project.py
@@ -2,7 +2,6 @@ from lxml import etree as ET
 import os, shutil
 import logging
 import tempfile
-import git
 from . import static, utils
 from . import build as builder
 from .static.pretext import pretext as core
@@ -302,6 +301,11 @@ class Project():
             shutil.rmtree(temp_xsl_dir)
 
     def deploy(self,target_name,commit_message="Update to PreTeXt project source."):
+        try:
+            import git
+        except ImportError:
+            log.critical("Git must be installed to use this feature, but couldn't be found.")
+            return None
         target = self.target(target_name)
         if target.format() != "html":
             log.error("Only HTML format targets are supported.")

--- a/pretext/project.py
+++ b/pretext/project.py
@@ -361,6 +361,8 @@ class Project():
         docs_path = os.path.join(self.__project_path,"docs")
         shutil.rmtree(docs_path,ignore_errors=True)
         shutil.copytree(target.output_dir(),docs_path)
+        with open(os.path.join(docs_path,'.nojekyll'), 'w') as fp:
+            pass
         log.info(f"Latest build copied to `{docs_path}`.")
         log.info("")
         repo.git.add('docs')

--- a/pretext/project.py
+++ b/pretext/project.py
@@ -301,7 +301,7 @@ class Project():
         if (temp_xsl_dir and os.path.exists(temp_xsl_dir)):
             shutil.rmtree(temp_xsl_dir)
 
-    def publish(self,target_name,commit_message="Update to PreTeXt project source."):
+    def deploy(self,target_name,commit_message="Update to PreTeXt project source."):
         target = self.target(target_name)
         if target.format() != "html":
             log.error("Only HTML format targets are supported.")
@@ -318,16 +318,16 @@ class Project():
         if not utils.directory_exists(target.output_dir()):
             log.error(f"The directory `{target.output_dir()}` does not exist. Maybe try `pretext build` first?")
             return
-        log.info(f"Preparing to publish the latest build located in `{target.output_dir()}`.")
+        log.info(f"Preparing to deploy the latest build located in `{target.output_dir()}`.")
         docs_path = os.path.join(self.__project_path,"docs")
         shutil.rmtree(docs_path,ignore_errors=True)
         shutil.copytree(target.output_dir(),docs_path)
         log.info(f"Latest build copied to `{docs_path}`.")
         repo.git.add('docs')
         try:
-            repo.git.commit(message=f"Publish latest build of target {target.name()}.")
+            repo.git.commit(message=f"Deploy latest build of target {target.name()}.")
         except git.exc.GitCommandError:
-            log.warning("Latest build is the same as last published build.")
+            log.warning("Latest build is the same as last deployed build.")
             pass
         log.info("Pushing to GitHub. (Your password may be required below.)")
         try:

--- a/templates/book/.gitignore
+++ b/templates/book/.gitignore
@@ -1,10 +1,16 @@
-# unpublished builds
+# ensure this file is tracked
+!.gitignore
+
+# don't track unpublished builds
 output
 
-# assets generated from source
+# don't track assets generated from source
 generated-assets
 
-# error logs
+# don't track node packages
+node_modules
+
+# don't track error logs
 .error_schema.log
 error_schema.log
 .error_syntax.log


### PR DESCRIPTION
Closes several issues related to `pretext deploy` (née `pretext publish`). Also adds a `requirements.txt` file to new projects pointing to the version of the CLI that generated it, so we'll see them at https://github.com/PreTeXtBook/pretext-cli/network/dependents when they push to GitHub.