### PR TITLE
set up local core install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,7 @@ pretext/static/pretext
 pretext/core/pretext.py
 pretext/static/schema
 pretext/static/xsl
+pretext/static/static.zip
 #shipped templates
 pretext/static/templates
 

--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -7,7 +7,6 @@ import os, zipfile, requests, io
 import tempfile, shutil
 import platform
 from pathlib import Path
-import sys
 from typing import Optional
 
 from . import utils, static, VERSION, CORE_COMMIT, core
@@ -137,7 +136,7 @@ def new(template,directory,url_template):
         r = requests.get(url_template)
         archive = zipfile.ZipFile(io.BytesIO(r.content))
     else:
-        template_path = static.path('templates', f'{template}.zip')
+        template_path = static.templates_path(f'{template}.zip')
         archive = zipfile.ZipFile(template_path)
     # find (first) project.ptx to use as root of template
     filenames = [Path(filepath).name for filepath in archive.namelist()]
@@ -175,7 +174,7 @@ def init(refresh):
         log.warning(f"Use `pretext init --refresh` to refresh initialization of an existing project.")
         return
     timestamp = datetime.datetime.now().strftime('%Y%m%d-%H%M%S')
-    template_manifest_path = static.path('templates', 'project.ptx')
+    template_manifest_path = static.templates_path('project.ptx')
     project_manifest_path = Path("project.ptx").resolve()
     if project_manifest_path.is_file():
         project_manifest_path = Path(f'project-{timestamp}.ptx').resolve()
@@ -195,7 +194,7 @@ def init(refresh):
     log.info(f"Generated requirements file at {requirements_path}.")
     log.info("")
     # Create publication file if one doesn't exist: 
-    template_pub_path = static.path('templates','publication.ptx')
+    template_pub_path = static.templates_path('publication.ptx')
     pub_dir_path = Path('publication')
     if not pub_dir_path.exists():
         pub_dir_path.mkdir()
@@ -208,7 +207,7 @@ def init(refresh):
     log.info(f"Generated publication file at {project_pub_path}.")
     log.info("")
     # Create .gitignore if one doesn't exist
-    template_gitignore_path = static.path('templates','.gitignore')
+    template_gitignore_path = static.templates_path('.gitignore')
     project_gitignore_path = Path(".gitignore").resolve()
     if project_gitignore_path.exists():
         project_gitignore_path = Path(f".gitignore-{timestamp}").resolve()

--- a/pretext/static/__init__.py
+++ b/pretext/static/__init__.py
@@ -7,16 +7,42 @@
 import os
 from pathlib import Path
 from lxml import etree as ET
+import zipfile
 from . import __file__ as STATIC_PATH
+from .. import utils
+from .. import CORE_COMMIT
 
-def path(*args): #TODO make pathlib.Path
+def path(*args) -> Path:
+    # Checks that the local static path ~/.ptx/ contains the static files needed for core, and installs them if they are missing (or if the version is different from the installed version of pretext).  Then returns the absolute path to the static files (appending arguments)
+    local_base_path = Path.home()/'.ptx'
+    local_commit_file = Path(local_base_path)/".commit"
+    if not Path.is_file(local_commit_file):
+        print("Static pretext files do not appear to be installed.  Installing now.")
+        install_static(local_base_path)
+    # check that the static core_commit matches current core_commit
+    with open(local_commit_file, "r") as f:
+        static_commit = f.readline()
+    if static_commit != CORE_COMMIT:
+        print("Static pretext files are out of date.  Installing them now.")
+        install_static(local_base_path)
+    return local_base_path.joinpath(*args)
+
+def install_static(local_base_path):
+    static_zip = (Path(STATIC_PATH).parent).joinpath("static.zip")
+    with zipfile.ZipFile(static_zip,"r") as zip:
+        zip.extractall(local_base_path)
+    # Write the current commit to local file
+    with open(local_base_path/".commit","w") as f:
+        f.write(CORE_COMMIT)
+    print(f"Static files required for pretext have now been installed to {local_base_path}")
+    return
+
+def templates_path(*args): #TODO make pathlib.Path
     """
     Returns absolute path to files in the static folder of the distribution.
     """
-    return os.path.abspath(os.path.join(
-        os.path.dirname(STATIC_PATH),
-        *args
-    ))
+    return (Path(STATIC_PATH).parent).joinpath("templates",
+        *args)
 
 def core_xsl(*args,as_path=False): #TODO deprecate
     xsl_path = path("xsl",*args)

--- a/pretext/utils.py
+++ b/pretext/utils.py
@@ -12,6 +12,7 @@ import socket
 import logging
 import threading
 import watchdog.events, watchdog.observers, time
+import zipfile
 from typing import Optional
 from lxml import etree as ET
 


### PR DESCRIPTION
With this commit, anytime `pretext` is run, we check whether the local version of the static files exist in `~/.ptx` (well, actually we just check for a `.commit` file with the commit corresponding to `CORE_COMMIT`).  If not, the (new) files are installed.  

Templates are still stored in the previous spot; so the call to that location had to be updated (now `static.templates_path()`.  

The `update_core.py` script now creates a zip of the core files in folders `css`, `schema`, `script`, and `xsl`.

This is a required change to implement #286 and will close #180 