### PR TITLE
add friendly errors for view/generate/deploy of non-targets

### DIFF
--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -330,6 +330,12 @@ def generate(assets:str, target:Optional[str], all_formats:bool, xmlid:Optional[
         return
     project = Project()
     target_name = target
+    target = project.target(name=target_name)
+    if target is None:
+        log.critical("Target for generating assets could not be found in project.ptx manifest.")
+        log.critical(f"Possible targets are: {project.target_names()}")
+        log.critical("Exiting without generating any assets.")
+        return
     if assets == 'ALL':
         log.info("Genearting all assets in default formats.")
         project.generate(target_name,xmlid=xmlid)
@@ -399,6 +405,11 @@ def view(target:str,access:str,port:Optional[int],directory:str,watch:bool,build
     target_name=target
     project = Project()
     target = project.target(name=target_name)
+    if target is None:
+        log.critical("View target could not be found in project.ptx manifest.")
+        log.critical(f"Possible targets are: {project.target_names()}")
+        log.critical("Exiting.")
+        return
     port = port or target.port()
     if target is None:
         log.error(f"Target `{target_name}` could not be found.")
@@ -434,6 +445,12 @@ def deploy(target,update_source):
         return
     target_name = target
     project = Project()
+    target = project.target(name=target_name)
+    if target is None or target.format() != "html":
+        log.critical("Target could not be found in project.ptx manifest.")
+        log.critical(f"Possible targets to deploy are: {project.target_names('html')}") #only list targets with html format.
+        log.critical("Exiting without completing task.")
+        return
     project.deploy(target_name,update_source)
 
 # pretext publish

--- a/pretext/project.py
+++ b/pretext/project.py
@@ -137,10 +137,12 @@ class Project():
             for target_element in self.xml_element().xpath("targets/target")
         ]
 
-    def target_names(self):
+    def target_names(self, *args):
+        # Optional arguments are formats: returns list of targets that have that format.
         names = []
         for target in self.targets():
-            names.append(target.name())
+            if not args or target.format() in args:
+                names.append(target.name())
         return names
 
     def print_target_names(self):
@@ -173,9 +175,6 @@ class Project():
 
     def build(self,target_name,clean=False):
         target = self.target(target_name)
-        if target is None:
-            log.error(f"Target {target_name} not found.")
-            return
         # Check for xml syntax errors and quit if xml invalid:
         if not self.xml_source_is_valid(target_name):
             return
@@ -289,7 +288,7 @@ class Project():
             log.error("Visit https://github.com/git-guides/install-git for assistance.")
             return
         target = self.target(target_name)
-        if target.format() != "html":
+        if target.format() != "html": #redundent for CLI
             log.error("Only HTML format targets are supported.")
             return
         try:


### PR DESCRIPTION
If a user tries to view or generate or deploy a target that isn't in `project.ptx`, there was an ugly traceback.  This provides a nicer error.  It also modifies the `project.target_names()` function to accept optional arguments to only list possible targets with provided formats, and catches attempted deploys that aren't for html builds earlier.

This pull request probably should have also included the previous commit (467c15d) which I just pushed directly (and failed on the tests, as mentioned in #295 ).