### PR TITLE
Improve pretext view, especially for non html formats

### DIFF
--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -385,7 +385,7 @@ def generate(assets:str, target:Optional[str], all_formats:bool, xmlid:Optional[
     type=click.Choice(ASSETS, case_sensitive=False), 
     help='Generate all or specific assets before viewing')
 @click.option(
-    '--no_launch', is_flag=True,
+    '--no-launch', is_flag=True,
     help='By default, pretext view tries to launch the default application to view the specified target.  Setting this suppresses this behavior.'
 )
 def view(target:str,access:str,port:Optional[int],directory:str,watch:bool,build:bool,generate:Optional[str],no_launch:bool):

--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -384,7 +384,11 @@ def generate(assets:str, target:Optional[str], all_formats:bool, xmlid:Optional[
     '-g', '--generate', is_flag=False, flag_value="ALL", default=None,
     type=click.Choice(ASSETS, case_sensitive=False), 
     help='Generate all or specific assets before viewing')
-def view(target:str,access:str,port:Optional[int],directory:str,watch:bool,build:bool,generate:Optional[str]):
+@click.option(
+    '--no_launch', is_flag=True,
+    help='By default, pretext view tries to launch the default application to view the specified target.  Setting this suppresses this behavior.'
+)
+def view(target:str,access:str,port:Optional[int],directory:str,watch:bool,build:bool,generate:Optional[str],no_launch:bool):
     """
     Starts a local server to preview built PreTeXt documents in your browser.
     TARGET is the name of the <target/> defined in `project.ptx`.
@@ -392,7 +396,7 @@ def view(target:str,access:str,port:Optional[int],directory:str,watch:bool,build
     # Easter egg to spin up a local server at a specified directory:
     if directory is not None:
         port = port or 8000
-        utils.run_server(Path(directory),access,port)
+        utils.run_server(Path(directory),access,port,no_launch=no_launch)
         return
     if utils.project_path() is None:
         log.critical("Before you can view your PreTeXt output, you must be in a (sub)directory initialized with a project.ptx manifest.")
@@ -414,7 +418,7 @@ def view(target:str,access:str,port:Optional[int],directory:str,watch:bool,build
     if build or watch:
         log.info("Building target.")
         project.build(target_name)
-    project.view(target_name,access,port,watch)
+    project.view(target_name,access,port,watch,no_launch)
 
 
 # pretext deploy

--- a/pretext/project.py
+++ b/pretext/project.py
@@ -8,6 +8,7 @@ from . import build as builder
 from pathlib import Path
 import sys
 from typing import Optional
+import webbrowser
 
 log = logging.getLogger('ptxlogger')
 
@@ -169,7 +170,12 @@ class Project():
             log.error(f"Run `pretext view {target.name()} -b` to build your project before viewing.")
             return
         watch_callback=lambda:self.build(target_name)
-        utils.run_server(directory,access,port,watch_directory,watch_callback)
+        if target.format() == 'html':
+            utils.run_server(directory,access,port,watch_directory,watch_callback)
+        else:
+            outputfile = sorted(Path(directory).glob("*.*"))[0]
+            log.info(f"Attempting to open {outputfile} using default viewer for {target.format()} files.")
+            webbrowser.open_new_tab(outputfile)
 
     def build(self,target_name,clean=False):
         target = self.target(target_name)

--- a/pretext/project.py
+++ b/pretext/project.py
@@ -158,7 +158,7 @@ class Project():
         else:
             return None
 
-    def view(self,target_name:str,access:str,port:int,watch:bool=False):
+    def view(self,target_name:str,access:str,port:int,watch:bool=False, no_launch:bool=False):
         target = self.target(target_name)
         directory = target.output_dir()
         if watch:
@@ -171,11 +171,14 @@ class Project():
             return
         watch_callback=lambda:self.build(target_name)
         if target.format() == 'html':
-            utils.run_server(directory,access,port,watch_directory,watch_callback)
+            utils.run_server(directory,access,port,watch_directory,watch_callback,no_launch)
         else:
-            outputfile = sorted(Path(directory).glob("*.*"))[0]
-            log.info(f"Attempting to open {outputfile} using default viewer for {target.format()} files.")
-            webbrowser.open_new_tab(outputfile)
+            if no_launch:
+                log.info(f"Output can be viewed by navigating to {directory}")
+            else:
+                outputfile = sorted(Path(directory).glob("*.*"))[0]
+                log.info(f"Attempting to open {outputfile} using default viewer for {target.format()} files.")
+                webbrowser.open(outputfile)
 
     def build(self,target_name,clean=False):
         target = self.target(target_name)

--- a/pretext/utils.py
+++ b/pretext/utils.py
@@ -180,7 +180,7 @@ def url_for_access(access="private",port=8000):
         return f"http://{socket.gethostbyname(socket.gethostname())}:{port}"
     else:
         return f"http://localhost:{port}"
-def serve_forever(directory:Path,access="private",port=8000):
+def serve_forever(directory:Path,access="private",port=8000,no_launch:bool=False):
     log.info(f"Now preparing local server to preview directory `{directory}`.")
     log.info("  (Reminder: use `pretext deploy` to deploy your built project to a public")
     log.info("  GitHub Pages site that can be shared with readers who cannot access your")
@@ -208,8 +208,9 @@ def serve_forever(directory:Path,access="private",port=8000):
                 url = url_for_access(access,port)
                 log.info(f"Success! The most recent build of your project can be viewed in a web browser at the following url:")
                 log.info("    "+url)
-                log.info(f"This page should open in a new tab automatically.")
-                webbrowser.open_new_tab(url)
+                if not no_launch:
+                    log.info(f"This page should open in a new tab automatically.")
+                    webbrowser.open(url)
                 log.info("Use [Ctrl]+[C] to halt the server.\n")
                 httpd.serve_forever()
         except OSError:
@@ -217,9 +218,9 @@ def serve_forever(directory:Path,access="private",port=8000):
             port = random.randint(49152,65535)
             log.warning(f"Trying port {port} instead.\n")
 
-def run_server(directory:Path,access:str,port:int,watch_directory:Optional[Path]=None,watch_callback=lambda:None):
+def run_server(directory:Path,access:str,port:int,watch_directory:Optional[Path]=None,watch_callback=lambda:None, no_launch:bool=False):
     binding = binding_for_access(access)
-    threading.Thread(target=lambda: serve_forever(directory,access,port),daemon=True).start()
+    threading.Thread(target=lambda: serve_forever(directory,access,port,no_launch),daemon=True).start()
     if watch_directory is not None:
         log.info(f"\nWatching for changes in `{watch_directory}` ...\n")
         event_handler = HTMLRebuildHandler(watch_callback)

--- a/pretext/utils.py
+++ b/pretext/utils.py
@@ -15,6 +15,7 @@ import logging
 import threading
 import watchdog.events, watchdog.observers, time
 import zipfile
+import webbrowser
 from typing import Optional
 from lxml import etree as ET
 
@@ -205,8 +206,10 @@ def serve_forever(directory:Path,access="private",port=8000):
             with TCPServer((binding, port), RequestHandler) as httpd:
                 looking_for_port = False
                 url = url_for_access(access,port)
-                log.info(f"Success! Open the below url in a web browser to preview the most recent build of your project.")
+                log.info(f"Success! The most recent build of your project can be viewed in a web browser at the following url:")
                 log.info("    "+url)
+                log.info(f"This page should open in a new tab automatically.")
+                webbrowser.open_new_tab(url)
                 log.info("Use [Ctrl]+[C] to halt the server.\n")
                 httpd.serve_forever()
         except OSError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ pretext = 'pretext.cli:main'
 [tool.poetry.dev-dependencies]
 pytest = "^7.0.0"
 pytest-console-scripts = "^1.3.1"
+pytest-mock = "^3.8.2"
 
 [tool.pytest.ini_options]
 script_launch_mode = "subprocess"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,7 @@ PY_CMD = sys.executable
 
 @contextmanager
 def pretext_view(*args):
-    process = subprocess.Popen([PTX_CMD,'-v','debug','view', '--no_launch']+list(args))
+    process = subprocess.Popen([PTX_CMD,'-v','debug','view', '--no-launch']+list(args))
     time.sleep(3) # stall for possible build
     try:
         yield process

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -73,7 +73,8 @@ def test_generate(tmp_path:Path,script_runner):
     assert script_runner.run(PTX_CMD,'-v','debug','generate','asymptote','-t', 'web', cwd=tmp_path).success
     os.remove(tmp_path/'generated-assets'/'asymptote'/'test.html')
 
-def test_view(tmp_path:Path,script_runner):
+def test_view(tmp_path:Path,script_runner,mocker):
+    mocker.patch('webbrowser.open_new_tab')
     os.chdir(tmp_path)
     port = random.randint(10_000, 65_536)
     with pretext_view('-d','.','-p',f'{port}'):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,7 @@ PY_CMD = sys.executable
 
 @contextmanager
 def pretext_view(*args):
-    process = subprocess.Popen([PTX_CMD,'-v','debug','view']+list(args))
+    process = subprocess.Popen([PTX_CMD,'-v','debug','view', '--no_launch']+list(args))
     time.sleep(3) # stall for possible build
     try:
         yield process
@@ -73,8 +73,7 @@ def test_generate(tmp_path:Path,script_runner):
     assert script_runner.run(PTX_CMD,'-v','debug','generate','asymptote','-t', 'web', cwd=tmp_path).success
     os.remove(tmp_path/'generated-assets'/'asymptote'/'test.html')
 
-def test_view(tmp_path:Path,script_runner,mocker):
-    mocker.patch('webbrowser.open_new_tab')
+def test_view(tmp_path:Path,script_runner):
     os.chdir(tmp_path)
     port = random.randint(10_000, 65_536)
     with pretext_view('-d','.','-p',f'{port}'):


### PR DESCRIPTION
I've attempted to use the `webbrowser` module to automatically open the localhost when we run `pretext view` and to open the other file when it is not an html formatted target.  I have no idea what happens with this in cocalc (I tried it, but don't have internet access, so perhaps that's why nothing happened).  If pdf doesn't do something nice in cocalc, we could serve that like html for cocalc users.

What do we want to do about view for non-html targets?  These seem like they would always take longer to build (I guess latex is pretty quick, but there is no reason you would want to get that output while watching).  We can just warn the user that the watch option only works with html builds, or try to do something more clever.