### PR TITLE
Codechat add

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ PyPDF2 = "~2.5"
 click-logging = "^1"
 ghp-import = "^2"
 single-version = "^1"
-CodeChat = "^1.9.2"
+CodeChat-Server = "^0.2.6"
 pyppeteer = "^1.0.2"
 
 [tool.poetry.scripts]

--- a/scripts/zip_templates.py
+++ b/scripts/zip_templates.py
@@ -15,7 +15,7 @@ def main():
                     temporary_path,
                     dirs_exist_ok=True,
                 )
-                template_files = ['project.ptx', '.gitignore']
+                template_files = ['project.ptx', '.gitignore', 'codechat_config.yaml']
                 for template_file in template_files:
                     copied_template_file = temporary_path/template_file
                     if not copied_template_file.is_file():

--- a/templates/codechat_config.yaml
+++ b/templates/codechat_config.yaml
@@ -1,0 +1,41 @@
+# .. Copyright (C) 2012-2020 Bryan A. Jones.
+#
+#  This file is part of the CodeChat System.
+#
+#  The CodeChat System is free software: you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License as
+#  published by the Free Software Foundation, either version 3 of the
+#  License, or (at your option) any later version.
+#
+#  The CodeChat System is distributed in the hope that it will be
+#  useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+#  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with the CodeChat System.  If not, see
+#  <http://www.gnu.org/licenses/>.
+#
+# ************************************************
+# |docname| - Configuration for a CodeChat project
+# ************************************************
+# This file defines the configuration for a CodeChat project. It contains a working `Sphinx <https://www.sphinx-doc.org/>`_ configuration.
+#
+# ``source_path``: optional; defaults to ``.`` (the current directory). A path to the root of the source tree. Relative paths are rooted in the directory containing this configuration file.
+source_path: source
+
+# ``output_path``: required. A path to the root of the HTML output produced by this renderer. Relative paths are rooted in the directory containing this configuration file.
+output_path: output/web
+
+# ``args``: required string or sequence of strings. This provides the arguments to invoke the renderer. These strings may optionally contain the following replacement values:
+#
+# - ``{project_path}``: an absolute path to the directory containing this file.
+# - ``{source_path}``: the ``source_path`` above, but as an absolute path.
+# - ``{output_path}``: the ``output_path`` above, but as an absolute path.
+args: pretext build web
+
+# ``html_ext``: optional; defaults to ``.html``. The extension used by this renderer when generating HTML files.
+#html_ext: .html
+
+# ``project_type``: optional; defaults to ``general``. Define the project type, which enables special processing based on the type. Valid values are ``general`` (no special processing), ``Doxygen``, and ``PreTeXt``.
+project_type: PreTeXt


### PR DESCRIPTION
Add the `codechat_config.yaml` file which allows the CodeChat System to build a PreTeXt book/article/etc.

Also corrects the dependency (on the CodeCode Server, instead of base CodeChat itself).