### PR TITLE
fix logic to give nice error when wrong target is requested

### DIFF
--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -265,22 +265,22 @@ def build(target, clean, generate):
     target = project.target(name=target_name)
     if target_name is None:
         log.info(f'Since no build target was supplied, the first target of the project.ptx manifest ({target.name()}) will be built.')
-    target_name = target.name()
+        target_name = target.name()
     if target is None:
         utils.show_target_hints(target_name, project, task="build")
         log.critical("Exiting without completing build.")
         return
     if generate=='ALL':
         log.info("Genearting all assets in default formats.")
-        project.generate(target_name)
+        project.generate(target.name())
     elif generate is not None:
         log.warning(f"Generating only {generate} assets.")
-        project.generate(target_name,asset_list=[generate])
+        project.generate(target.name(),asset_list=[generate])
     else:
         log.warning("Assets like latex-images will not be regenerated for this build")
         log.warning("(previously generated assets will be used if they exist).")
         log.warning("To generate these assets before building, run `pretext build -g`.")
-    project.build(target_name,clean)
+    project.build(target.name(),clean)
 
 # pretext generate
 @main.command(short_help="Generate specified assets for specified target", 

--- a/pretext/utils.py
+++ b/pretext/utils.py
@@ -347,7 +347,7 @@ def show_target_hints(target_format:str, project, task:str):
         if target_format in ['epub', 'kindle']:
             log.info(f"Instructions for setting up a target with the {target_format} format, including the external programs required, can be found in the PreTeXt guide: https://pretextbook.org/doc/guide/html/epub.html")
     else:
-        log.info(f"The available targets to {task} are named: {project.target_names()}.  Try to {task} on of those instead or edition your proejct.ptx manifest.")
+        log.info(f"The available targets to {task} are named: {project.target_names()}.  Try to {task} on of those instead or edit your proejct.ptx manifest.")
 
 def npm_install():
     with working_directory(core.resources.path("script", "mjsre")):


### PR DESCRIPTION
Fixed missing indentation.  Also fixed a typo, and made generate and build parameters consistent (which doesn't change functionality).

Will close #345 