### PR TITLE
add runestone version reporting to support

### DIFF
--- a/pretext/__init__.py
+++ b/pretext/__init__.py
@@ -18,7 +18,7 @@ from single_version import get_version
 VERSION = get_version('pretext', Path(__file__).parent.parent)
 
 
-CORE_COMMIT = "7da2caf946ab2eb698f82cf95a99bfde01590401"
+CORE_COMMIT = "51bdbaeecdb6fe2098c545a47b1141ff955b0d08"
 
 
 def activate():

--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Optional
 import atexit
 
-from . import utils, templates, VERSION, CORE_COMMIT
+from . import utils, templates, core, VERSION, CORE_COMMIT
 from .project import Project
 
 
@@ -104,9 +104,10 @@ def support():
     log.info(f"PreTeXt-CLI version: {VERSION}")
     log.info(f"    PyPI link: https://pypi.org/project/pretextbook/{VERSION}/")
     log.info(f"PreTeXt core resources commit: {CORE_COMMIT}")
+    log.info(f"Runestone Services version: {core.get_runestone_services_version()}")
     log.info(f"OS: {platform.platform()}")
     log.info(f"Python version: {platform.python_version()}")
-    log.info(f"Current working directory: {Path()}")
+    log.info(f"Current working directory: {Path().resolve()}")
     if utils.project_path() is not None:
         log.info(f"PreTeXt project path: {utils.project_path()}")
         log.info("")


### PR DESCRIPTION
Thanks @rbeezer for setting this up.  It was a very easy addition.

Note to @StevenClontz: I also changed the reporting of current working directory to use `Path().resolve()`; it was just always giving `.`.  I don't think this is wrong, but let me know if I'm overlooking something.

Will close #347 