### PR TITLE
Add a helpful error message if core pretext.py is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,12 @@ with this command.
 poetry install
 ```
 
+Before you attempt to run `pretext` locally, you must fetch a copy of the core pretext library by running
+
+```
+python scripts/fetch_core.py
+```
+
 Then to use the in-development package, you can either enter a poetry shell:
 
 ```

--- a/pretext/core/__init__.py
+++ b/pretext/core/__init__.py
@@ -1,4 +1,10 @@
-from .pretext import *
+try:
+    from .pretext import *
+except ImportError as e:
+    raise ImportError(
+        "Failed to import the core pretext.py file. Perhaps the file is unavailable? "
+        "Run `scripts/fetch_core.py` to grab a copy of pretex core.\n"
+        "The original error message is: " + e.msg)
 from . import resources
 
 set_ptx_path(resources.path())


### PR DESCRIPTION
This is a fix for #364 