### PR TITLE
Reformat with pep8

### DIFF
--- a/.github/workflows/test-on-push.yml
+++ b/.github/workflows/test-on-push.yml
@@ -44,3 +44,7 @@ jobs:
     - name: Test with pytest
       run: |
         python -m poetry run pytest -v
+
+    - name: Check formatting with black
+      run: |
+        python -m poetry run black --check $(git ls-files |grep -e "\.py$")

--- a/.github/workflows/test-on-push.yml
+++ b/.github/workflows/test-on-push.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         python-version: "3.10"
 
-    - name: Install poetry ${{ matrix.poetry-version }}
+    - name: Install poetry 1.1.13
       run: |
         python -m ensurepip
         python -m pip install --upgrade pip

--- a/.github/workflows/test-on-push.yml
+++ b/.github/workflows/test-on-push.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.10
+        python-version: "3.10"
 
     - name: Install poetry ${{ matrix.poetry-version }}
       run: |

--- a/.github/workflows/test-on-push.yml
+++ b/.github/workflows/test-on-push.yml
@@ -7,6 +7,29 @@ on:
     branches: [ main ]
 
 jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.10
+
+    - name: Install poetry ${{ matrix.poetry-version }}
+      run: |
+        python -m ensurepip
+        python -m pip install --upgrade pip
+        python -m pip install poetry==1.1.13
+
+    - name: Install dependencies
+      shell: bash
+      run:  |
+        python -m poetry install
+
+    - name: Check formatting with black
+      run: |
+        python -m poetry run black --check --diff $(git ls-files |grep -e "\.py$")
+
   build:
     strategy:
       fail-fast: false
@@ -44,7 +67,3 @@ jobs:
     - name: Test with pytest
       run: |
         python -m poetry run pytest -v
-
-    - name: Check formatting with black
-      run: |
-        python -m poetry run black --check $(git ls-files |grep -e "\.py$")

--- a/.github/workflows/test-on-push.yml
+++ b/.github/workflows/test-on-push.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Check formatting with black
       run: |
-        python -m poetry run black --check --diff $(git ls-files |grep -e "\.py$")
+        python -m poetry run black --check --diff $(git ls-files "*.py")
 
   build:
     strategy:

--- a/.github/workflows/test-on-push.yml
+++ b/.github/workflows/test-on-push.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-      uses: actions/setup-python@v4
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.10
 

--- a/README.md
+++ b/README.md
@@ -258,6 +258,17 @@ running:
 poetry run python scripts/zip_templates.py
 ```
 
+### Formatting code before a commit
+
+All `.py` files are formatted with the `black` python formatter. Proper formatting
+is enforced by checks in the Continuous Integration framework. Before you commit code,
+you should make sure it is formatted with `black` by running the following command (on linux or mac)
+from the _root_ project folder (most likely `pretext-cli`).
+
+```
+poetry run black $(git ls-files "*.py")
+```
+
 ### Testing
 
 Sets are contained in `tests/`. To run all tests:

--- a/pretext/__init__.py
+++ b/pretext/__init__.py
@@ -28,6 +28,6 @@ def activate():
     we were allowed to adopt this namespace as of 1.0, so we raise an error here
     to help anyone who might have upgraded from the original package.
     """
-    raise RuntimeError("As of version 1.0, the `pretext` PyPI package has been "+
-        "transferred to PreTeXtBook.org. Install a <1.0 version to use the "+
-        "pretext.activate() feature from the original `pretext` package.")
+    raise RuntimeError("As of version 1.0, the `pretext` PyPI package has been " +
+                       "transferred to PreTeXtBook.org. Install a <1.0 version to use the " +
+                       "pretext.activate() feature from the original `pretext` package.")

--- a/pretext/__init__.py
+++ b/pretext/__init__.py
@@ -15,7 +15,8 @@
 
 from pathlib import Path
 from single_version import get_version
-VERSION = get_version('pretext', Path(__file__).parent.parent)
+
+VERSION = get_version("pretext", Path(__file__).parent.parent)
 
 
 CORE_COMMIT = "4e3fc1098911520e7ab0ebc7e0a860ba37954faa"
@@ -28,6 +29,8 @@ def activate():
     we were allowed to adopt this namespace as of 1.0, so we raise an error here
     to help anyone who might have upgraded from the original package.
     """
-    raise RuntimeError("As of version 1.0, the `pretext` PyPI package has been " +
-                       "transferred to PreTeXtBook.org. Install a <1.0 version to use the " +
-                       "pretext.activate() feature from the original `pretext` package.")
+    raise RuntimeError(
+        "As of version 1.0, the `pretext` PyPI package has been "
+        + "transferred to PreTeXtBook.org. Install a <1.0 version to use the "
+        + "pretext.activate() feature from the original `pretext` package."
+    )

--- a/pretext/build.py
+++ b/pretext/build.py
@@ -7,18 +7,26 @@ from typing import Optional
 from . import utils, core
 
 # Get access to logger
-log = logging.getLogger('ptxlogger')
+log = logging.getLogger("ptxlogger")
 
 
-def html(ptxfile: Path, pub_file: Path, output: Path, stringparams, custom_xsl: Optional[Path], xmlid_root, zipped=False):
+def html(
+    ptxfile: Path,
+    pub_file: Path,
+    output: Path,
+    stringparams,
+    custom_xsl: Optional[Path],
+    xmlid_root,
+    zipped=False,
+):
     os.makedirs(output, exist_ok=True)
     log.info(f"\nNow building HTML into {output}\n")
     if xmlid_root is not None:
         log.info(f"Only building @xml:id `{xmlid_root}`\n")
     if zipped:
-        file_format = 'zip'
+        file_format = "zip"
     else:
-        file_format = 'html'
+        file_format = "html"
     # ensure working directory is preserved
     with utils.working_directory(Path()):
         try:
@@ -30,16 +38,22 @@ def html(ptxfile: Path, pub_file: Path, output: Path, stringparams, custom_xsl: 
                 file_format,
                 custom_xsl and custom_xsl.as_posix(),  # pass None or posix string
                 None,
-                output.as_posix()
+                output.as_posix(),
             )
         except Exception as e:
             log.critical(e)
             log.debug(f"Exception info:\n##################\n", exc_info=True)
-            log.info('##################')
-            sys.exit('Failed to build html.  Exiting...')
+            log.info("##################")
+            sys.exit("Failed to build html.  Exiting...")
 
 
-def latex(ptxfile: Path, pub_file: Path, output: Path, stringparams, custom_xsl: Optional[Path]):
+def latex(
+    ptxfile: Path,
+    pub_file: Path,
+    output: Path,
+    stringparams,
+    custom_xsl: Optional[Path],
+):
     os.makedirs(output, exist_ok=True)
     log.info(f"\nNow building LaTeX into {output}\n")
     # ensure working directory is preserved
@@ -51,16 +65,23 @@ def latex(ptxfile: Path, pub_file: Path, output: Path, stringparams, custom_xsl:
                 stringparams,
                 custom_xsl and custom_xsl.as_posix(),  # pass None or posix string
                 None,
-                output.as_posix()
+                output.as_posix(),
             )
         except Exception as e:
             log.critical(e)
             log.debug(f"Exception info:\n##################\n", exc_info=True)
-            log.info('##################')
-            sys.exit('Failed to build latex.  Exiting...')
+            log.info("##################")
+            sys.exit("Failed to build latex.  Exiting...")
 
 
-def pdf(ptxfile: Path, pub_file: Path, output: Path, stringparams, custom_xsl: Optional[Path], pdf_method: str):
+def pdf(
+    ptxfile: Path,
+    pub_file: Path,
+    output: Path,
+    stringparams,
+    custom_xsl: Optional[Path],
+    pdf_method: str,
+):
     os.makedirs(output, exist_ok=True)
     log.info(f"\nNow building LaTeX into {output}\n")
     # ensure working directory is preserved
@@ -73,22 +94,28 @@ def pdf(ptxfile: Path, pub_file: Path, output: Path, stringparams, custom_xsl: O
                 custom_xsl and custom_xsl.as_posix(),  # pass None or posix string
                 None,
                 dest_dir=output.as_posix(),
-                method=pdf_method
+                method=pdf_method,
             )
         except Exception as e:
             log.critical(e)
             log.debug(f"Exception info:\n##################\n", exc_info=True)
-            log.info('##################')
-            sys.exit('Failed to build pdf.  Exiting...')
+            log.info("##################")
+            sys.exit("Failed to build pdf.  Exiting...")
 
 
-def custom(ptxfile: Path, pub_file: Path, output: Path, stringparams, custom_xsl: Path, output_filename: Optional[str] = None):
+def custom(
+    ptxfile: Path,
+    pub_file: Path,
+    output: Path,
+    stringparams,
+    custom_xsl: Path,
+    output_filename: Optional[str] = None,
+):
     os.makedirs(output, exist_ok=True)
     if output_filename is not None:
-        output_filepath = output/output_filename
+        output_filepath = output / output_filename
         output_dir = None
-        log.info(
-            f"\nNow building with custom {custom_xsl} into {output_filepath}\n")
+        log.info(f"\nNow building with custom {custom_xsl} into {output_filepath}\n")
     else:
         output_filepath = None
         output_dir = output
@@ -96,13 +123,19 @@ def custom(ptxfile: Path, pub_file: Path, output: Path, stringparams, custom_xsl
     # ensure working directory is preserved
     with utils.working_directory(Path()):
         try:
-            core.xsltproc(custom_xsl, ptxfile, output_filepath,
-                          output_dir=output_dir, stringparams=stringparams)
+            core.xsltproc(
+                custom_xsl,
+                ptxfile,
+                output_filepath,
+                output_dir=output_dir,
+                stringparams=stringparams,
+            )
         except Exception as e:
             log.critical(e)
             log.debug(f"Exception info:\n##################\n", exc_info=True)
-            log.info('##################')
-            sys.exit('Failed custom build.  Exiting...')
+            log.info("##################")
+            sys.exit("Failed custom build.  Exiting...")
+
 
 # build (non Kindle) ePub:
 
@@ -114,7 +147,8 @@ def epub(ptxfile, pub_file: Path, output: Path, stringparams):
     except Exception as e:
         log.debug(e)
         sys.exit(
-            "Unable to build epub because node packages are not installed.  Exiting...")
+            "Unable to build epub because node packages are not installed.  Exiting..."
+        )
     log.info(f"\nNow building ePub into {output}\n")
     with utils.working_directory("."):
         try:
@@ -124,12 +158,13 @@ def epub(ptxfile, pub_file: Path, output: Path, stringparams):
                 out_file=None,  # will be derived from source
                 dest_dir=output.as_posix(),
                 math_format="svg",
-                stringparams=stringparams)
+                stringparams=stringparams,
+            )
         except Exception as e:
             log.critical(e)
             log.debug(f"Exception info:\n##################\n", exc_info=True)
-            log.info('##################')
-            sys.exit('Failed to build epub.  Exiting...')
+            log.info("##################")
+            sys.exit("Failed to build epub.  Exiting...")
 
 
 # build Kindle ePub:
@@ -140,7 +175,8 @@ def kindle(ptxfile, pub_file: Path, output: Path, stringparams):
     except Exception as e:
         log.critical(e)
         sys.exit(
-            "Unable to build Kindle ePub because node packages are not installed.  Exiting...")
+            "Unable to build Kindle ePub because node packages are not installed.  Exiting..."
+        )
     log.info(f"\nNow building Kindle ePub into {output}\n")
     with utils.working_directory("."):
         try:
@@ -150,24 +186,30 @@ def kindle(ptxfile, pub_file: Path, output: Path, stringparams):
                 out_file=None,  # will be derived from source
                 dest_dir=output.as_posix(),
                 math_format="kindle",
-                stringparams=stringparams)
+                stringparams=stringparams,
+            )
         except Exception as e:
             log.critical(e)
             log.debug(f"Exception info:\n##################\n", exc_info=True)
-            log.info('##################')
-            sys.exit('Failed to build kindle ebook.  Exiting...')
+            log.info("##################")
+            sys.exit("Failed to build kindle ebook.  Exiting...")
+
+
 # build Braille:
 
 
 def braille(ptxfile, pub_file: Path, output: Path, stringparams, page_format="emboss"):
     os.makedirs(output, exist_ok=True)
-    log.warning("Braille output is still experimental, and requires additional libraries from liblouis (specifically the file2brl software).")
+    log.warning(
+        "Braille output is still experimental, and requires additional libraries from liblouis (specifically the file2brl software)."
+    )
     try:
         utils.npm_install()
     except Exception as e:
         log.debug(e)
         sys.exit(
-            "Unable to build braille because node packages could not be installed.  Exiting...")
+            "Unable to build braille because node packages could not be installed.  Exiting..."
+        )
     log.info(f"\nNow building braille into {output}\n")
     with utils.working_directory("."):
         try:
@@ -177,9 +219,10 @@ def braille(ptxfile, pub_file: Path, output: Path, stringparams, page_format="em
                 out_file=None,  # will be derived from source
                 dest_dir=output.as_posix(),
                 page_format=page_format,  # could be "eboss" or "electronic"
-                stringparams=stringparams)
+                stringparams=stringparams,
+            )
         except Exception as e:
             log.critical(e)
             log.debug(f"Exception info:\n##################\n", exc_info=True)
-            log.info('##################')
-            sys.exit('Failed to build braille.  Exiting...')
+            log.info("##################")
+            sys.exit("Failed to build braille.  Exiting...")

--- a/pretext/build.py
+++ b/pretext/build.py
@@ -9,7 +9,8 @@ from . import utils, core
 # Get access to logger
 log = logging.getLogger('ptxlogger')
 
-def html(ptxfile:Path,pub_file:Path,output:Path,stringparams,custom_xsl:Optional[Path],xmlid_root,zipped=False):
+
+def html(ptxfile: Path, pub_file: Path, output: Path, stringparams, custom_xsl: Optional[Path], xmlid_root, zipped=False):
     os.makedirs(output, exist_ok=True)
     log.info(f"\nNow building HTML into {output}\n")
     if xmlid_root is not None:
@@ -18,7 +19,8 @@ def html(ptxfile:Path,pub_file:Path,output:Path,stringparams,custom_xsl:Optional
         file_format = 'zip'
     else:
         file_format = 'html'
-    with utils.working_directory(Path()): # ensure working directory is preserved
+    # ensure working directory is preserved
+    with utils.working_directory(Path()):
         try:
             core.html(
                 ptxfile,
@@ -26,7 +28,7 @@ def html(ptxfile:Path,pub_file:Path,output:Path,stringparams,custom_xsl:Optional
                 stringparams,
                 xmlid_root,
                 file_format,
-                custom_xsl and custom_xsl.as_posix(), # pass None or posix string
+                custom_xsl and custom_xsl.as_posix(),  # pass None or posix string
                 None,
                 output.as_posix()
             )
@@ -36,17 +38,19 @@ def html(ptxfile:Path,pub_file:Path,output:Path,stringparams,custom_xsl:Optional
             log.info('##################')
             sys.exit('Failed to build html.  Exiting...')
 
-def latex(ptxfile:Path,pub_file:Path,output:Path,stringparams,custom_xsl:Optional[Path]):
+
+def latex(ptxfile: Path, pub_file: Path, output: Path, stringparams, custom_xsl: Optional[Path]):
     os.makedirs(output, exist_ok=True)
     log.info(f"\nNow building LaTeX into {output}\n")
-    with utils.working_directory(Path()): # ensure working directory is preserved
+    # ensure working directory is preserved
+    with utils.working_directory(Path()):
         try:
             core.latex(
-                ptxfile, 
-                pub_file.as_posix(), 
-                stringparams, 
-                custom_xsl and custom_xsl.as_posix(), # pass None or posix string
-                None, 
+                ptxfile,
+                pub_file.as_posix(),
+                stringparams,
+                custom_xsl and custom_xsl.as_posix(),  # pass None or posix string
+                None,
                 output.as_posix()
             )
         except Exception as e:
@@ -55,18 +59,20 @@ def latex(ptxfile:Path,pub_file:Path,output:Path,stringparams,custom_xsl:Optiona
             log.info('##################')
             sys.exit('Failed to build latex.  Exiting...')
 
-def pdf(ptxfile:Path,pub_file:Path,output:Path,stringparams,custom_xsl:Optional[Path],pdf_method:str):
+
+def pdf(ptxfile: Path, pub_file: Path, output: Path, stringparams, custom_xsl: Optional[Path], pdf_method: str):
     os.makedirs(output, exist_ok=True)
     log.info(f"\nNow building LaTeX into {output}\n")
-    with utils.working_directory(Path()): # ensure working directory is preserved
+    # ensure working directory is preserved
+    with utils.working_directory(Path()):
         try:
             core.pdf(
-                ptxfile, 
-                pub_file.as_posix(), 
-                stringparams, 
-                custom_xsl and custom_xsl.as_posix(), # pass None or posix string
-                None, 
-                dest_dir=output.as_posix(), 
+                ptxfile,
+                pub_file.as_posix(),
+                stringparams,
+                custom_xsl and custom_xsl.as_posix(),  # pass None or posix string
+                None,
+                dest_dir=output.as_posix(),
                 method=pdf_method
             )
         except Exception as e:
@@ -76,42 +82,48 @@ def pdf(ptxfile:Path,pub_file:Path,output:Path,stringparams,custom_xsl:Optional[
             sys.exit('Failed to build pdf.  Exiting...')
 
 
-def custom(ptxfile:Path,pub_file:Path,output:Path,stringparams,custom_xsl:Path,output_filename:Optional[str]=None):
+def custom(ptxfile: Path, pub_file: Path, output: Path, stringparams, custom_xsl: Path, output_filename: Optional[str] = None):
     os.makedirs(output, exist_ok=True)
     if output_filename is not None:
         output_filepath = output/output_filename
         output_dir = None
-        log.info(f"\nNow building with custom {custom_xsl} into {output_filepath}\n")
+        log.info(
+            f"\nNow building with custom {custom_xsl} into {output_filepath}\n")
     else:
         output_filepath = None
         output_dir = output
         log.info(f"\nNow building with custom {custom_xsl} into {output}\n")
-    with utils.working_directory(Path()): # ensure working directory is preserved
+    # ensure working directory is preserved
+    with utils.working_directory(Path()):
         try:
-            core.xsltproc(custom_xsl, ptxfile, output_filepath, output_dir=output_dir, stringparams=stringparams)
+            core.xsltproc(custom_xsl, ptxfile, output_filepath,
+                          output_dir=output_dir, stringparams=stringparams)
         except Exception as e:
             log.critical(e)
             log.debug(f"Exception info:\n##################\n", exc_info=True)
             log.info('##################')
             sys.exit('Failed custom build.  Exiting...')
 
-#build (non Kindle) ePub:
-def epub(ptxfile,pub_file:Path,output:Path,stringparams):
+# build (non Kindle) ePub:
+
+
+def epub(ptxfile, pub_file: Path, output: Path, stringparams):
     os.makedirs(output, exist_ok=True)
     try:
         utils.npm_install()
     except Exception as e:
         log.debug(e)
-        sys.exit("Unable to build epub because node packages are not installed.  Exiting...")
+        sys.exit(
+            "Unable to build epub because node packages are not installed.  Exiting...")
     log.info(f"\nNow building ePub into {output}\n")
     with utils.working_directory("."):
         try:
             core.epub(
-                ptxfile, 
+                ptxfile,
                 pub_file.as_posix(),
-                out_file=None, #will be derived from source
-                dest_dir=output.as_posix(), 
-                math_format="svg", 
+                out_file=None,  # will be derived from source
+                dest_dir=output.as_posix(),
+                math_format="svg",
                 stringparams=stringparams)
         except Exception as e:
             log.critical(e)
@@ -120,47 +132,51 @@ def epub(ptxfile,pub_file:Path,output:Path,stringparams):
             sys.exit('Failed to build epub.  Exiting...')
 
 
-#build Kindle ePub:
-def kindle(ptxfile,pub_file:Path,output:Path,stringparams):
+# build Kindle ePub:
+def kindle(ptxfile, pub_file: Path, output: Path, stringparams):
     os.makedirs(output, exist_ok=True)
     try:
         utils.npm_install()
     except Exception as e:
         log.critical(e)
-        sys.exit("Unable to build Kindle ePub because node packages are not installed.  Exiting...")
+        sys.exit(
+            "Unable to build Kindle ePub because node packages are not installed.  Exiting...")
     log.info(f"\nNow building Kindle ePub into {output}\n")
     with utils.working_directory("."):
         try:
             core.epub(
-                ptxfile, 
-                pub_file.as_posix(), 
-                out_file=None, #will be derived from source
-                dest_dir=output.as_posix(), 
-                math_format="kindle", 
+                ptxfile,
+                pub_file.as_posix(),
+                out_file=None,  # will be derived from source
+                dest_dir=output.as_posix(),
+                math_format="kindle",
                 stringparams=stringparams)
         except Exception as e:
             log.critical(e)
             log.debug(f"Exception info:\n##################\n", exc_info=True)
             log.info('##################')
             sys.exit('Failed to build kindle ebook.  Exiting...')
-#build Braille:
-def braille(ptxfile,pub_file:Path,output:Path,stringparams,page_format="emboss"):
+# build Braille:
+
+
+def braille(ptxfile, pub_file: Path, output: Path, stringparams, page_format="emboss"):
     os.makedirs(output, exist_ok=True)
     log.warning("Braille output is still experimental, and requires additional libraries from liblouis (specifically the file2brl software).")
     try:
         utils.npm_install()
     except Exception as e:
         log.debug(e)
-        sys.exit("Unable to build braille because node packages could not be installed.  Exiting...")
+        sys.exit(
+            "Unable to build braille because node packages could not be installed.  Exiting...")
     log.info(f"\nNow building braille into {output}\n")
     with utils.working_directory("."):
         try:
             core.braille(
-                xml_source=ptxfile, 
+                xml_source=ptxfile,
                 pub_file=pub_file.as_posix(),
-                out_file=None, #will be derived from source
-                dest_dir=output.as_posix(), 
-                page_format=page_format,#could be "eboss" or "electronic"
+                out_file=None,  # will be derived from source
+                dest_dir=output.as_posix(),
+                page_format=page_format,  # could be "eboss" or "electronic"
                 stringparams=stringparams)
         except Exception as e:
             log.critical(e)

--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -1,12 +1,18 @@
 from concurrent.futures.process import _threads_wakeups
 from pickle import FALSE
-import logging, logging.handlers, sys
+import logging
+import logging.handlers
+import sys
 import click
 import click_log
 import shutil
 import datetime
-import os, zipfile, requests, io
-import tempfile, shutil
+import os
+import zipfile
+import requests
+import io
+import tempfile
+import shutil
 import platform
 from pathlib import Path
 from typing import Optional
@@ -22,11 +28,12 @@ click_log_format = click_log.ColorFormatter()
 # create memory handler which displays error and critical messages at the end as well.
 sh = logging.StreamHandler(sys.stderr)
 sh.setFormatter(click_log_format)
-mh = logging.handlers.MemoryHandler(capacity=1024*100, flushLevel=100,target=sh, flushOnClose=False)
+mh = logging.handlers.MemoryHandler(
+    capacity=1024*100, flushLevel=100, target=sh, flushOnClose=False)
 mh.setLevel(logging.ERROR)
 log.addHandler(mh)
 
-#Call exit_command() at close to handle errors incountered during run.
+# Call exit_command() at close to handle errors encountered during run.
 atexit.register(utils.exit_command, mh)
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
@@ -40,9 +47,9 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
     log,
     help="Sets the severity of log messaging: DEBUG for all, INFO (default) for most, then WARNING, ERROR, and CRITICAL for decreasing verbosity."
 )
-@click.version_option(VERSION,message=VERSION)
+@click.version_option(VERSION, message=VERSION)
 @click.option('-t', '--targets', is_flag=True, help='Display list of build/view "targets" available in the project manifest.')
-def main(ctx,targets):
+def main(ctx, targets):
     """
     Command line tools for quickly creating, authoring, and building PreTeXt projects.
 
@@ -64,32 +71,38 @@ def main(ctx,targets):
         # create file handler which logs even debug messages
         fh = logging.FileHandler(utils.project_path()/'cli.log', mode='w')
         fh.setLevel(logging.DEBUG)
-        file_log_format = logging.Formatter('{levelname:<8}: {message}',style='{')
+        file_log_format = logging.Formatter(
+            '{levelname:<8}: {message}', style='{')
         fh.setFormatter(file_log_format)
         log.addHandler(fh)
         # output info
         log.info(f"PreTeXt project found in `{utils.project_path()}`.")
-        # permanently change working directory for rest of processs
+        # permanently change working directory for rest of process
         os.chdir(utils.project_path())
         if utils.requirements_version() is None:
-            log.warning("Project's CLI version could not be detected from `requirements.txt`.")
-            log.warning("Try `pretext init --refresh` to produce a compatible file.")
+            log.warning(
+                "Project's CLI version could not be detected from `requirements.txt`.")
+            log.warning(
+                "Try `pretext init --refresh` to produce a compatible file.")
         elif utils.requirements_version() != VERSION:
-            log.warning(f"Using CLI version {VERSION} but project's `requirements.txt`")
-            log.warning(f"is configured to use {utils.requirements_version()}. Consider either installing")
-            log.warning(f"CLI version {utils.requirements_version()} or changing `requirements.txt` to match {VERSION}.")
+            log.warning(
+                f"Using CLI version {VERSION} but project's `requirements.txt`")
+            log.warning(
+                f"is configured to use {utils.requirements_version()}. Consider either installing")
+            log.warning(
+                f"CLI version {utils.requirements_version()} or changing `requirements.txt` to match {VERSION}.")
         else:
-            log.debug(f"CLI version {VERSION} matches requirements.txt {utils.requirements_version()}.")
+            log.debug(
+                f"CLI version {VERSION} matches requirements.txt {utils.requirements_version()}.")
     else:
         log.info("No existing PreTeXt project found.")
     if ctx.invoked_subcommand is None:
         log.info("Run `pretext --help` for help.")
 
 
-
 # pretext support
 @main.command(
-    short_help="Use when communicating with PreTeXt support.", 
+    short_help="Use when communicating with PreTeXt support.",
     context_settings=CONTEXT_SETTINGS)
 def support():
     """
@@ -104,7 +117,8 @@ def support():
     log.info(f"PreTeXt-CLI version: {VERSION}")
     log.info(f"    PyPI link: https://pypi.org/project/pretextbook/{VERSION}/")
     log.info(f"PreTeXt core resources commit: {CORE_COMMIT}")
-    log.info(f"Runestone Services version: {core.get_runestone_services_version()}")
+    log.info(
+        f"Runestone Services version: {core.get_runestone_services_version()}")
     log.info(f"OS: {platform.platform()}")
     log.info(f"Python version: {platform.python_version()}")
     log.info(f"Current working directory: {Path().resolve()}")
@@ -126,15 +140,15 @@ def support():
 
 
 # pretext new
-@main.command(short_help="Generates the necessary files for a new PreTeXt project.", 
-    context_settings=CONTEXT_SETTINGS)
+@main.command(short_help="Generates the necessary files for a new PreTeXt project.",
+              context_settings=CONTEXT_SETTINGS)
 @click.argument('template', default='book',
-              type=click.Choice(['book', 'article', 'hello', 'slideshow'], case_sensitive=False))
+                type=click.Choice(['book', 'article', 'hello', 'slideshow'], case_sensitive=False))
 @click.option('-d', '--directory', type=click.Path(), default='new-pretext-project',
               help="Directory to create/use for the project.")
 @click.option('-u', '--url-template', type=click.STRING,
               help="Download a zipped template from its URL.")
-def new(template,directory,url_template):
+def new(template, directory, url_template):
     """
     Generates the necessary files for a new PreTeXt project.
     Supports `pretext new book` (default) and `pretext new article`,
@@ -142,10 +156,12 @@ def new(template,directory,url_template):
     """
     directory_fullpath = Path(directory).resolve()
     if utils.project_path(directory_fullpath) is not None:
-        log.warning(f"A project already exists in `{utils.project_path(directory_fullpath)}`.")
+        log.warning(
+            f"A project already exists in `{utils.project_path(directory_fullpath)}`.")
         log.warning(f"No new project will be generated.")
         return
-    log.info(f"Generating new PreTeXt project in `{directory_fullpath}` using `{template}` template.")
+    log.info(
+        f"Generating new PreTeXt project in `{directory_fullpath}` using `{template}` template.")
     if url_template is not None:
         r = requests.get(url_template)
         archive = zipfile.ZipFile(io.BytesIO(r.content))
@@ -159,64 +175,74 @@ def new(template,directory,url_template):
     project_dir_path = project_ptx_path.parent
     with tempfile.TemporaryDirectory() as tmpdirname:
         for filepath in [filepath for filepath in archive.namelist() if project_dir_path in Path(filepath).parents]:
-            archive.extract(filepath,path=tmpdirname)
+            archive.extract(filepath, path=tmpdirname)
         tmpsubdirname = Path(tmpdirname)/project_dir_path
-        shutil.copytree(tmpsubdirname,directory,dirs_exist_ok=True)
+        shutil.copytree(tmpsubdirname, directory, dirs_exist_ok=True)
     # generate requirements.txt
-    with open(directory_fullpath/"requirements.txt","w") as f:
+    with open(directory_fullpath/"requirements.txt", "w") as f:
         f.write(f"pretext == {VERSION}")
-    log.info(f"Success! Open `{directory_fullpath}/source/main.ptx` to edit your document")
-    log.info(f"Then try to `pretext build` and `pretext view` from within `{directory_fullpath}`.")
+    log.info(
+        f"Success! Open `{directory_fullpath}/source/main.ptx` to edit your document")
+    log.info(
+        f"Then try to `pretext build` and `pretext view` from within `{directory_fullpath}`.")
 
 
 # pretext init
-@main.command(short_help="Generates the project manifest for a PreTeXt project in the current directory.", 
-    context_settings=CONTEXT_SETTINGS)
-@click.option('-r', '--refresh', is_flag=True, 
+@main.command(short_help="Generates the project manifest for a PreTeXt project in the current directory.",
+              context_settings=CONTEXT_SETTINGS)
+@click.option('-r', '--refresh', is_flag=True,
               help="Refresh initialization of project even if project.ptx exists.")
 def init(refresh):
     """
     Generates the project manifest for a PreTeXt project in the current directory. This feature
     is mainly intended for updating existing projects to use this CLI.
 
-    If --refresh is used, files will be generated even if the project has already been initalized.
+    If --refresh is used, files will be generated even if the project has already been initialized.
     Existing files won't be overwritten; a copy of the fresh initialized file will be created
     with a timestamp in its filename for comparison.
     """
     if utils.project_path() is not None and not refresh:
         log.warning(f"A project already exists in `{utils.project_path()}`.")
-        log.warning(f"Use `pretext init --refresh` to refresh initialization of an existing project.")
+        log.warning(
+            f"Use `pretext init --refresh` to refresh initialization of an existing project.")
         return
     timestamp = datetime.datetime.now().strftime('%Y%m%d-%H%M%S')
     with templates.resource_path('project.ptx') as template_manifest_path:
         project_manifest_path = Path("project.ptx").resolve()
         if project_manifest_path.is_file():
             project_manifest_path = Path(f'project-{timestamp}.ptx').resolve()
-            log.warning(f"You already have a project file at {Path('project.ptx').resolve()}.")
-            log.warning(f"A default project file has been created as {project_manifest_path} for comparison.")
+            log.warning(
+                f"You already have a project file at {Path('project.ptx').resolve()}.")
+            log.warning(
+                f"A default project file has been created as {project_manifest_path} for comparison.")
         log.info(f"Generated project file at `{project_manifest_path}`.")
         log.info("")
-        shutil.copyfile(template_manifest_path,project_manifest_path)
+        shutil.copyfile(template_manifest_path, project_manifest_path)
     # Create requirements.txt
     requirements_path = Path('requirements.txt').resolve()
     if requirements_path.exists():
         requirements_path = Path(f'requirements-{timestamp}.txt').resolve()
-        log.warning(f"You already have a requirements.txt file at {Path('requirements.txt').resolve()}`.")
-        log.warning(f"The one suggested by PreTeXt will be created as {requirements_path} for comparison.")
-    with open(requirements_path,"w") as f:
+        log.warning(
+            f"You already have a requirements.txt file at {Path('requirements.txt').resolve()}`.")
+        log.warning(
+            f"The one suggested by PreTeXt will be created as {requirements_path} for comparison.")
+    with open(requirements_path, "w") as f:
         f.write(f"pretext == {VERSION}")
     log.info(f"Generated requirements file at {requirements_path}.")
     log.info("")
-    # Create publication file if one doesn't exist: 
+    # Create publication file if one doesn't exist:
     with templates.resource_path("publication.ptx") as template_pub_path:
         pub_dir_path = Path('publication')
         if not pub_dir_path.exists():
             pub_dir_path.mkdir()
         project_pub_path = (pub_dir_path/'publication.ptx').resolve()
         if project_pub_path.exists():
-            project_pub_path = (Path('publication')/f'publication-{timestamp}.ptx').resolve()
-            log.warning(f"You already have a publication file at {(Path('publication')/'publication.ptx').resolve()}.")
-            log.warning(f"A default project file has been created as {project_pub_path} for comparison.")
+            project_pub_path = (Path('publication') /
+                                f'publication-{timestamp}.ptx').resolve()
+            log.warning(
+                f"You already have a publication file at {(Path('publication')/'publication.ptx').resolve()}.")
+            log.warning(
+                f"A default project file has been created as {project_pub_path} for comparison.")
         shutil.copyfile(template_pub_path, project_pub_path)
         log.info(f"Generated publication file at {project_pub_path}.")
         log.info("")
@@ -225,25 +251,32 @@ def init(refresh):
         project_gitignore_path = Path(".gitignore").resolve()
         if project_gitignore_path.exists():
             project_gitignore_path = Path(f".gitignore-{timestamp}").resolve()
-            log.warning(f"You already have a gitignore file at {Path('.gitignore').resolve()}.")
-            log.warning(f"A default project file has been created as {project_gitignore_path} for comparison.")
-        shutil.copyfile(template_gitignore_path,project_gitignore_path)
+            log.warning(
+                f"You already have a gitignore file at {Path('.gitignore').resolve()}.")
+            log.warning(
+                f"A default project file has been created as {project_gitignore_path} for comparison.")
+        shutil.copyfile(template_gitignore_path, project_gitignore_path)
     log.info(f"Generated .gitignore file at {project_gitignore_path}.")
     log.info("")
     # End by reporting success
     log.info(f"Success! Open project.ptx to edit your project manifest.")
-    log.info(f"Edit your <target/>s to point to the location of your PreTeXt source files.")
+    log.info(
+        f"Edit your <target/>s to point to the location of your PreTeXt source files.")
 
-ASSETS = ['ALL', 'webwork', 'latex-image', 'sageplot', 'asymptote', 'interactive', 'youtube', 'codelens']
+
+ASSETS = ['ALL', 'webwork', 'latex-image', 'sageplot',
+          'asymptote', 'interactive', 'youtube', 'codelens']
 
 # pretext build
-@main.command(short_help="Build specified target", 
-    context_settings=CONTEXT_SETTINGS)
+
+
+@main.command(short_help="Build specified target",
+              context_settings=CONTEXT_SETTINGS)
 @click.argument('target', required=False)
 @click.option('--clean', is_flag=True, help="Destroy output's target directory before build to clean up previously built files")
 @click.option(
     '-g', '--generate', is_flag=False, flag_value="ALL", default=None,
-    type=click.Choice(ASSETS, case_sensitive=False), 
+    type=click.Choice(ASSETS, case_sensitive=False),
     help='Generates assets for target.  -g [asset] will generate the specific assets given.')
 def build(target, clean, generate):
     """
@@ -265,36 +298,41 @@ def build(target, clean, generate):
     project = Project()
     target = project.target(name=target_name)
     if target_name is None:
-        log.info(f'Since no build target was supplied, the first target of the project.ptx manifest ({target.name()}) will be built.')
+        log.info(
+            f'Since no build target was supplied, the first target of the project.ptx manifest ({target.name()}) will be built.')
         target_name = target.name()
     if target is None:
         utils.show_target_hints(target_name, project, task="build")
         log.critical("Exiting without completing build.")
         return
-    if generate=='ALL':
-        log.info("Genearting all assets in default formats.")
+    if generate == 'ALL':
+        log.info("Generating all assets in default formats.")
         project.generate(target.name())
     elif generate is not None:
         log.warning(f"Generating only {generate} assets.")
-        project.generate(target.name(),asset_list=[generate])
+        project.generate(target.name(), asset_list=[generate])
     else:
-        log.warning("Assets like latex-images will not be regenerated for this build")
+        log.warning(
+            "Assets like latex-images will not be regenerated for this build")
         log.warning("(previously generated assets will be used if they exist).")
-        log.warning("To generate these assets before building, run `pretext build -g`.")
-    project.build(target.name(),clean)
+        log.warning(
+            "To generate these assets before building, run `pretext build -g`.")
+    project.build(target.name(), clean)
 
 # pretext generate
-@main.command(short_help="Generate specified assets for specified target", 
-    context_settings=CONTEXT_SETTINGS)
+
+
+@main.command(short_help="Generate specified assets for specified target",
+              context_settings=CONTEXT_SETTINGS)
 @click.argument('assets', default="ALL",
-    type=click.Choice(ASSETS, case_sensitive=False))
+                type=click.Choice(ASSETS, case_sensitive=False))
 @click.option(
     '-t', '--target', type=click.STRING, help="Name of target to generate assets for (if not specified, first target from manifest is used).")
 @click.option(
     '-x', '--xmlid', type=click.STRING, help="xml:id of element to be generated.")
-@click.option('--all-formats', is_flag=True, default=False, 
-    help='Generate all possible asset formats rather than just the defaults for the specified target.')
-def generate(assets:str, target:Optional[str], all_formats:bool, xmlid:Optional[str]):
+@click.option('--all-formats', is_flag=True, default=False,
+              help='Generate all possible asset formats rather than just the defaults for the specified target.')
+def generate(assets: str, target: Optional[str], all_formats: bool, xmlid: Optional[str]):
     """
     Generate specified (or all) assets for the default target (first target in "project.ptx"). Asset "generation" is typically
     slower and performed less frequently than "building" a project, but is
@@ -311,27 +349,36 @@ def generate(assets:str, target:Optional[str], all_formats:bool, xmlid:Optional[
     target_name = target
     target = project.target(name=target_name)
     if target_name == None:
-        log.info(f'Since no target was specified with the -t flag, we will generate assets for the first target in the manifest ({target.name()}).')
+        log.info(
+            f'Since no target was specified with the -t flag, we will generate assets for the first target in the manifest ({target.name()}).')
     if target is None:
-        utils.show_target_hints(target_name, project, task="generating assets for")
+        utils.show_target_hints(target_name, project,
+                                task="generating assets for")
         log.critical("Exiting without generating any assets.")
         return
     if all_formats and assets == 'ALL':
-        log.info(f'Generating all assets in all asset formats for the target "{target.name()}".')
+        log.info(
+            f'Generating all assets in all asset formats for the target "{target.name()}".')
         project.generate(target.name(), all_formats=True, xmlid=xmlid)
     elif all_formats:
-        log.info(f'Generating only {assets} assets in all asset formats for the target "{target.name()}".')
-        project.generate(target.name(), asset_list=[assets], all_formats=True, xmlid=xmlid)
+        log.info(
+            f'Generating only {assets} assets in all asset formats for the target "{target.name()}".')
+        project.generate(target.name(), asset_list=[
+                         assets], all_formats=True, xmlid=xmlid)
     elif assets == 'ALL':
-        log.info(f'Genearting all assets in default formats for the target "{target.name()}".')
-        project.generate(target.name(),xmlid=xmlid)
+        log.info(
+            f'Generating all assets in default formats for the target "{target.name()}".')
+        project.generate(target.name(), xmlid=xmlid)
     else:
-        log.info(f'Generating only {assets} assets in default formats for the target "{target.name()}".')
-        project.generate(target.name(),asset_list=[assets],xmlid=xmlid)
+        log.info(
+            f'Generating only {assets} assets in default formats for the target "{target.name()}".')
+        project.generate(target.name(), asset_list=[assets], xmlid=xmlid)
 
 # pretext view
+
+
 @main.command(short_help="Preview specified target based on its format.",
-    context_settings=CONTEXT_SETTINGS)
+              context_settings=CONTEXT_SETTINGS)
 @click.argument('target', required=False)
 @click.option(
     '-a',
@@ -373,13 +420,13 @@ def generate(assets:str, target:Optional[str], all_formats:bool, xmlid:Optional[
     """)
 @click.option(
     '-g', '--generate', is_flag=False, flag_value="ALL", default=None,
-    type=click.Choice(ASSETS, case_sensitive=False), 
+    type=click.Choice(ASSETS, case_sensitive=False),
     help='Generate all or specific assets before viewing')
 @click.option(
     '--no-launch', is_flag=True,
     help='By default, pretext view tries to launch the default application to view the specified target.  Setting this suppresses this behavior.'
 )
-def view(target:str,access:str,port:Optional[int],directory:str,watch:bool,build:bool,generate:Optional[str],no_launch:bool):
+def view(target: str, access: str, port: Optional[int], directory: str, watch: bool, build: bool, generate: Optional[str], no_launch: bool):
     """
     Starts a local server to preview built PreTeXt documents in your browser.
     TARGET is the name of the <target/> defined in `project.ptx`.
@@ -387,11 +434,11 @@ def view(target:str,access:str,port:Optional[int],directory:str,watch:bool,build
     # Easter egg to spin up a local server at a specified directory:
     if directory is not None:
         port = port or 8000
-        utils.run_server(Path(directory),access,port,no_launch=no_launch)
+        utils.run_server(Path(directory), access, port, no_launch=no_launch)
         return
     if utils.no_project(task="view the output for"):
         return
-    target_name=target
+    target_name = target
     project = Project()
     target = project.target(name=target_name)
     if target is None:
@@ -404,19 +451,19 @@ def view(target:str,access:str,port:Optional[int],directory:str,watch:bool,build
         project.generate(target_name)
     elif generate is not None:
         log.warning(f"Generating only {generate} assets.")
-        project.generate(target_name,asset_list=[generate])
+        project.generate(target_name, asset_list=[generate])
     if build or watch:
         log.info("Building target.")
         project.build(target_name)
-    project.view(target_name,access,port,watch,no_launch)
+    project.view(target_name, access, port, watch, no_launch)
 
 
 # pretext deploy
 @main.command(short_help="Deploys Git-managed project to GitHub Pages.",
-    context_settings=CONTEXT_SETTINGS)
+              context_settings=CONTEXT_SETTINGS)
 @click.argument('target', required=False)
 @click.option('-u', '--update_source', is_flag=True, required=False)
-def deploy(target,update_source):
+def deploy(target, update_source):
     """
     Automatically deploys most recent build of [TARGET] to GitHub Pages,
     making it available to the general public.
@@ -431,7 +478,9 @@ def deploy(target,update_source):
     target = project.target(name=target_name)
     if target is None or target.format() != "html":
         log.critical("Target could not be found in project.ptx manifest.")
-        log.critical(f"Possible html targets to deploy are: {project.target_names('html')}") #only list targets with html format.
+        # only list targets with html format.
+        log.critical(
+            f"Possible html targets to deploy are: {project.target_names('html')}")
         log.critical("Exiting without completing task.")
         return
-    project.deploy(target_name,update_source)
+    project.deploy(target_name, update_source)

--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -22,21 +22,22 @@ from . import utils, templates, core, VERSION, CORE_COMMIT
 from .project import Project
 
 
-log = logging.getLogger('ptxlogger')
+log = logging.getLogger("ptxlogger")
 click_log.basic_config(log)
 click_log_format = click_log.ColorFormatter()
 # create memory handler which displays error and critical messages at the end as well.
 sh = logging.StreamHandler(sys.stderr)
 sh.setFormatter(click_log_format)
 mh = logging.handlers.MemoryHandler(
-    capacity=1024*100, flushLevel=100, target=sh, flushOnClose=False)
+    capacity=1024 * 100, flushLevel=100, target=sh, flushOnClose=False
+)
 mh.setLevel(logging.ERROR)
 log.addHandler(mh)
 
 # Call exit_command() at close to handle errors encountered during run.
 atexit.register(utils.exit_command, mh)
 
-CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 
 #  Click command-line interface
@@ -45,10 +46,15 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 # Allow a verbosity command:
 @click_log.simple_verbosity_option(
     log,
-    help="Sets the severity of log messaging: DEBUG for all, INFO (default) for most, then WARNING, ERROR, and CRITICAL for decreasing verbosity."
+    help="Sets the severity of log messaging: DEBUG for all, INFO (default) for most, then WARNING, ERROR, and CRITICAL for decreasing verbosity.",
 )
 @click.version_option(VERSION, message=VERSION)
-@click.option('-t', '--targets', is_flag=True, help='Display list of build/view "targets" available in the project manifest.')
+@click.option(
+    "-t",
+    "--targets",
+    is_flag=True,
+    help='Display list of build/view "targets" available in the project manifest.',
+)
 def main(ctx, targets):
     """
     Command line tools for quickly creating, authoring, and building PreTeXt projects.
@@ -69,10 +75,9 @@ def main(ctx, targets):
             Project().print_target_names()
             return
         # create file handler which logs even debug messages
-        fh = logging.FileHandler(utils.project_path()/'cli.log', mode='w')
+        fh = logging.FileHandler(utils.project_path() / "cli.log", mode="w")
         fh.setLevel(logging.DEBUG)
-        file_log_format = logging.Formatter(
-            '{levelname:<8}: {message}', style='{')
+        file_log_format = logging.Formatter("{levelname:<8}: {message}", style="{")
         fh.setFormatter(file_log_format)
         log.addHandler(fh)
         # output info
@@ -81,19 +86,21 @@ def main(ctx, targets):
         os.chdir(utils.project_path())
         if utils.requirements_version() is None:
             log.warning(
-                "Project's CLI version could not be detected from `requirements.txt`.")
-            log.warning(
-                "Try `pretext init --refresh` to produce a compatible file.")
+                "Project's CLI version could not be detected from `requirements.txt`."
+            )
+            log.warning("Try `pretext init --refresh` to produce a compatible file.")
         elif utils.requirements_version() != VERSION:
+            log.warning(f"Using CLI version {VERSION} but project's `requirements.txt`")
             log.warning(
-                f"Using CLI version {VERSION} but project's `requirements.txt`")
+                f"is configured to use {utils.requirements_version()}. Consider either installing"
+            )
             log.warning(
-                f"is configured to use {utils.requirements_version()}. Consider either installing")
-            log.warning(
-                f"CLI version {utils.requirements_version()} or changing `requirements.txt` to match {VERSION}.")
+                f"CLI version {utils.requirements_version()} or changing `requirements.txt` to match {VERSION}."
+            )
         else:
             log.debug(
-                f"CLI version {VERSION} matches requirements.txt {utils.requirements_version()}.")
+                f"CLI version {VERSION} matches requirements.txt {utils.requirements_version()}."
+            )
     else:
         log.info("No existing PreTeXt project found.")
     if ctx.invoked_subcommand is None:
@@ -103,7 +110,8 @@ def main(ctx, targets):
 # pretext support
 @main.command(
     short_help="Use when communicating with PreTeXt support.",
-    context_settings=CONTEXT_SETTINGS)
+    context_settings=CONTEXT_SETTINGS,
+)
 def support():
     """
     Outputs useful information about your installation needed by
@@ -117,8 +125,7 @@ def support():
     log.info(f"PreTeXt-CLI version: {VERSION}")
     log.info(f"    PyPI link: https://pypi.org/project/pretextbook/{VERSION}/")
     log.info(f"PreTeXt core resources commit: {CORE_COMMIT}")
-    log.info(
-        f"Runestone Services version: {core.get_runestone_services_version()}")
+    log.info(f"Runestone Services version: {core.get_runestone_services_version()}")
     log.info(f"OS: {platform.platform()}")
     log.info(f"Python version: {platform.python_version()}")
     log.info(f"Current working directory: {Path().resolve()}")
@@ -134,20 +141,35 @@ def support():
         for exec_name in project.executables():
             if utils.check_executable(exec_name) is None:
                 log.warning(
-                    f"Unable to locate the command for <{exec_name}> on your system.")
+                    f"Unable to locate the command for <{exec_name}> on your system."
+                )
     else:
         log.info("No project.ptx found.")
 
 
 # pretext new
-@main.command(short_help="Generates the necessary files for a new PreTeXt project.",
-              context_settings=CONTEXT_SETTINGS)
-@click.argument('template', default='book',
-                type=click.Choice(['book', 'article', 'hello', 'slideshow'], case_sensitive=False))
-@click.option('-d', '--directory', type=click.Path(), default='new-pretext-project',
-              help="Directory to create/use for the project.")
-@click.option('-u', '--url-template', type=click.STRING,
-              help="Download a zipped template from its URL.")
+@main.command(
+    short_help="Generates the necessary files for a new PreTeXt project.",
+    context_settings=CONTEXT_SETTINGS,
+)
+@click.argument(
+    "template",
+    default="book",
+    type=click.Choice(["book", "article", "hello", "slideshow"], case_sensitive=False),
+)
+@click.option(
+    "-d",
+    "--directory",
+    type=click.Path(),
+    default="new-pretext-project",
+    help="Directory to create/use for the project.",
+)
+@click.option(
+    "-u",
+    "--url-template",
+    type=click.STRING,
+    help="Download a zipped template from its URL.",
+)
 def new(template, directory, url_template):
     """
     Generates the necessary files for a new PreTeXt project.
@@ -157,41 +179,55 @@ def new(template, directory, url_template):
     directory_fullpath = Path(directory).resolve()
     if utils.project_path(directory_fullpath) is not None:
         log.warning(
-            f"A project already exists in `{utils.project_path(directory_fullpath)}`.")
+            f"A project already exists in `{utils.project_path(directory_fullpath)}`."
+        )
         log.warning(f"No new project will be generated.")
         return
     log.info(
-        f"Generating new PreTeXt project in `{directory_fullpath}` using `{template}` template.")
+        f"Generating new PreTeXt project in `{directory_fullpath}` using `{template}` template."
+    )
     if url_template is not None:
         r = requests.get(url_template)
         archive = zipfile.ZipFile(io.BytesIO(r.content))
     else:
-        with templates.resource_path(f'{template}.zip') as template_path:
+        with templates.resource_path(f"{template}.zip") as template_path:
             archive = zipfile.ZipFile(template_path)
     # find (first) project.ptx to use as root of template
     filenames = [Path(filepath).name for filepath in archive.namelist()]
-    project_ptx_index = filenames.index('project.ptx')
+    project_ptx_index = filenames.index("project.ptx")
     project_ptx_path = Path(archive.namelist()[project_ptx_index])
     project_dir_path = project_ptx_path.parent
     with tempfile.TemporaryDirectory() as tmpdirname:
-        for filepath in [filepath for filepath in archive.namelist() if project_dir_path in Path(filepath).parents]:
+        for filepath in [
+            filepath
+            for filepath in archive.namelist()
+            if project_dir_path in Path(filepath).parents
+        ]:
             archive.extract(filepath, path=tmpdirname)
-        tmpsubdirname = Path(tmpdirname)/project_dir_path
+        tmpsubdirname = Path(tmpdirname) / project_dir_path
         shutil.copytree(tmpsubdirname, directory, dirs_exist_ok=True)
     # generate requirements.txt
-    with open(directory_fullpath/"requirements.txt", "w") as f:
+    with open(directory_fullpath / "requirements.txt", "w") as f:
         f.write(f"pretext == {VERSION}")
     log.info(
-        f"Success! Open `{directory_fullpath}/source/main.ptx` to edit your document")
+        f"Success! Open `{directory_fullpath}/source/main.ptx` to edit your document"
+    )
     log.info(
-        f"Then try to `pretext build` and `pretext view` from within `{directory_fullpath}`.")
+        f"Then try to `pretext build` and `pretext view` from within `{directory_fullpath}`."
+    )
 
 
 # pretext init
-@main.command(short_help="Generates the project manifest for a PreTeXt project in the current directory.",
-              context_settings=CONTEXT_SETTINGS)
-@click.option('-r', '--refresh', is_flag=True,
-              help="Refresh initialization of project even if project.ptx exists.")
+@main.command(
+    short_help="Generates the project manifest for a PreTeXt project in the current directory.",
+    context_settings=CONTEXT_SETTINGS,
+)
+@click.option(
+    "-r",
+    "--refresh",
+    is_flag=True,
+    help="Refresh initialization of project even if project.ptx exists.",
+)
 def init(refresh):
     """
     Generates the project manifest for a PreTeXt project in the current directory. This feature
@@ -204,80 +240,107 @@ def init(refresh):
     if utils.project_path() is not None and not refresh:
         log.warning(f"A project already exists in `{utils.project_path()}`.")
         log.warning(
-            f"Use `pretext init --refresh` to refresh initialization of an existing project.")
+            f"Use `pretext init --refresh` to refresh initialization of an existing project."
+        )
         return
-    timestamp = datetime.datetime.now().strftime('%Y%m%d-%H%M%S')
-    with templates.resource_path('project.ptx') as template_manifest_path:
+    timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+    with templates.resource_path("project.ptx") as template_manifest_path:
         project_manifest_path = Path("project.ptx").resolve()
         if project_manifest_path.is_file():
-            project_manifest_path = Path(f'project-{timestamp}.ptx').resolve()
+            project_manifest_path = Path(f"project-{timestamp}.ptx").resolve()
             log.warning(
-                f"You already have a project file at {Path('project.ptx').resolve()}.")
+                f"You already have a project file at {Path('project.ptx').resolve()}."
+            )
             log.warning(
-                f"A default project file has been created as {project_manifest_path} for comparison.")
+                f"A default project file has been created as {project_manifest_path} for comparison."
+            )
         log.info(f"Generated project file at `{project_manifest_path}`.")
         log.info("")
         shutil.copyfile(template_manifest_path, project_manifest_path)
     # Create requirements.txt
-    requirements_path = Path('requirements.txt').resolve()
+    requirements_path = Path("requirements.txt").resolve()
     if requirements_path.exists():
-        requirements_path = Path(f'requirements-{timestamp}.txt').resolve()
+        requirements_path = Path(f"requirements-{timestamp}.txt").resolve()
         log.warning(
-            f"You already have a requirements.txt file at {Path('requirements.txt').resolve()}`.")
+            f"You already have a requirements.txt file at {Path('requirements.txt').resolve()}`."
+        )
         log.warning(
-            f"The one suggested by PreTeXt will be created as {requirements_path} for comparison.")
+            f"The one suggested by PreTeXt will be created as {requirements_path} for comparison."
+        )
     with open(requirements_path, "w") as f:
         f.write(f"pretext == {VERSION}")
     log.info(f"Generated requirements file at {requirements_path}.")
     log.info("")
     # Create publication file if one doesn't exist:
     with templates.resource_path("publication.ptx") as template_pub_path:
-        pub_dir_path = Path('publication')
+        pub_dir_path = Path("publication")
         if not pub_dir_path.exists():
             pub_dir_path.mkdir()
-        project_pub_path = (pub_dir_path/'publication.ptx').resolve()
+        project_pub_path = (pub_dir_path / "publication.ptx").resolve()
         if project_pub_path.exists():
-            project_pub_path = (Path('publication') /
-                                f'publication-{timestamp}.ptx').resolve()
+            project_pub_path = (
+                Path("publication") / f"publication-{timestamp}.ptx"
+            ).resolve()
             log.warning(
-                f"You already have a publication file at {(Path('publication')/'publication.ptx').resolve()}.")
+                f"You already have a publication file at {(Path('publication')/'publication.ptx').resolve()}."
+            )
             log.warning(
-                f"A default project file has been created as {project_pub_path} for comparison.")
+                f"A default project file has been created as {project_pub_path} for comparison."
+            )
         shutil.copyfile(template_pub_path, project_pub_path)
         log.info(f"Generated publication file at {project_pub_path}.")
         log.info("")
     # Create .gitignore if one doesn't exist
-    with templates.resource_path('.gitignore') as template_gitignore_path:
+    with templates.resource_path(".gitignore") as template_gitignore_path:
         project_gitignore_path = Path(".gitignore").resolve()
         if project_gitignore_path.exists():
             project_gitignore_path = Path(f".gitignore-{timestamp}").resolve()
             log.warning(
-                f"You already have a gitignore file at {Path('.gitignore').resolve()}.")
+                f"You already have a gitignore file at {Path('.gitignore').resolve()}."
+            )
             log.warning(
-                f"A default project file has been created as {project_gitignore_path} for comparison.")
+                f"A default project file has been created as {project_gitignore_path} for comparison."
+            )
         shutil.copyfile(template_gitignore_path, project_gitignore_path)
     log.info(f"Generated .gitignore file at {project_gitignore_path}.")
     log.info("")
     # End by reporting success
     log.info(f"Success! Open project.ptx to edit your project manifest.")
     log.info(
-        f"Edit your <target/>s to point to the location of your PreTeXt source files.")
+        f"Edit your <target/>s to point to the location of your PreTeXt source files."
+    )
 
 
-ASSETS = ['ALL', 'webwork', 'latex-image', 'sageplot',
-          'asymptote', 'interactive', 'youtube', 'codelens']
+ASSETS = [
+    "ALL",
+    "webwork",
+    "latex-image",
+    "sageplot",
+    "asymptote",
+    "interactive",
+    "youtube",
+    "codelens",
+]
 
 # pretext build
 
 
-@main.command(short_help="Build specified target",
-              context_settings=CONTEXT_SETTINGS)
-@click.argument('target', required=False)
-@click.option('--clean', is_flag=True, help="Destroy output's target directory before build to clean up previously built files")
+@main.command(short_help="Build specified target", context_settings=CONTEXT_SETTINGS)
+@click.argument("target", required=False)
 @click.option(
-    '-g', '--generate', is_flag=False, flag_value="ALL", default=None,
+    "--clean",
+    is_flag=True,
+    help="Destroy output's target directory before build to clean up previously built files",
+)
+@click.option(
+    "-g",
+    "--generate",
+    is_flag=False,
+    flag_value="ALL",
+    default=None,
     type=click.Choice(ASSETS, case_sensitive=False),
-    help='Generates assets for target.  -g [asset] will generate the specific assets given.')
+    help="Generates assets for target.  -g [asset] will generate the specific assets given.",
+)
 def build(target, clean, generate):
     """
     Build [TARGET] according to settings specified by project.ptx.
@@ -299,40 +362,54 @@ def build(target, clean, generate):
     target = project.target(name=target_name)
     if target_name is None:
         log.info(
-            f'Since no build target was supplied, the first target of the project.ptx manifest ({target.name()}) will be built.')
+            f"Since no build target was supplied, the first target of the project.ptx manifest ({target.name()}) will be built."
+        )
         target_name = target.name()
     if target is None:
         utils.show_target_hints(target_name, project, task="build")
         log.critical("Exiting without completing build.")
         return
-    if generate == 'ALL':
+    if generate == "ALL":
         log.info("Generating all assets in default formats.")
         project.generate(target.name())
     elif generate is not None:
         log.warning(f"Generating only {generate} assets.")
         project.generate(target.name(), asset_list=[generate])
     else:
-        log.warning(
-            "Assets like latex-images will not be regenerated for this build")
+        log.warning("Assets like latex-images will not be regenerated for this build")
         log.warning("(previously generated assets will be used if they exist).")
-        log.warning(
-            "To generate these assets before building, run `pretext build -g`.")
+        log.warning("To generate these assets before building, run `pretext build -g`.")
     project.build(target.name(), clean)
+
 
 # pretext generate
 
 
-@main.command(short_help="Generate specified assets for specified target",
-              context_settings=CONTEXT_SETTINGS)
-@click.argument('assets', default="ALL",
-                type=click.Choice(ASSETS, case_sensitive=False))
+@main.command(
+    short_help="Generate specified assets for specified target",
+    context_settings=CONTEXT_SETTINGS,
+)
+@click.argument(
+    "assets", default="ALL", type=click.Choice(ASSETS, case_sensitive=False)
+)
 @click.option(
-    '-t', '--target', type=click.STRING, help="Name of target to generate assets for (if not specified, first target from manifest is used).")
+    "-t",
+    "--target",
+    type=click.STRING,
+    help="Name of target to generate assets for (if not specified, first target from manifest is used).",
+)
 @click.option(
-    '-x', '--xmlid', type=click.STRING, help="xml:id of element to be generated.")
-@click.option('--all-formats', is_flag=True, default=False,
-              help='Generate all possible asset formats rather than just the defaults for the specified target.')
-def generate(assets: str, target: Optional[str], all_formats: bool, xmlid: Optional[str]):
+    "-x", "--xmlid", type=click.STRING, help="xml:id of element to be generated."
+)
+@click.option(
+    "--all-formats",
+    is_flag=True,
+    default=False,
+    help="Generate all possible asset formats rather than just the defaults for the specified target.",
+)
+def generate(
+    assets: str, target: Optional[str], all_formats: bool, xmlid: Optional[str]
+):
     """
     Generate specified (or all) assets for the default target (first target in "project.ptx"). Asset "generation" is typically
     slower and performed less frequently than "building" a project, but is
@@ -350,83 +427,119 @@ def generate(assets: str, target: Optional[str], all_formats: bool, xmlid: Optio
     target = project.target(name=target_name)
     if target_name == None:
         log.info(
-            f'Since no target was specified with the -t flag, we will generate assets for the first target in the manifest ({target.name()}).')
+            f"Since no target was specified with the -t flag, we will generate assets for the first target in the manifest ({target.name()})."
+        )
     if target is None:
-        utils.show_target_hints(target_name, project,
-                                task="generating assets for")
+        utils.show_target_hints(target_name, project, task="generating assets for")
         log.critical("Exiting without generating any assets.")
         return
-    if all_formats and assets == 'ALL':
+    if all_formats and assets == "ALL":
         log.info(
-            f'Generating all assets in all asset formats for the target "{target.name()}".')
+            f'Generating all assets in all asset formats for the target "{target.name()}".'
+        )
         project.generate(target.name(), all_formats=True, xmlid=xmlid)
     elif all_formats:
         log.info(
-            f'Generating only {assets} assets in all asset formats for the target "{target.name()}".')
-        project.generate(target.name(), asset_list=[
-                         assets], all_formats=True, xmlid=xmlid)
-    elif assets == 'ALL':
+            f'Generating only {assets} assets in all asset formats for the target "{target.name()}".'
+        )
+        project.generate(
+            target.name(), asset_list=[assets], all_formats=True, xmlid=xmlid
+        )
+    elif assets == "ALL":
         log.info(
-            f'Generating all assets in default formats for the target "{target.name()}".')
+            f'Generating all assets in default formats for the target "{target.name()}".'
+        )
         project.generate(target.name(), xmlid=xmlid)
     else:
         log.info(
-            f'Generating only {assets} assets in default formats for the target "{target.name()}".')
+            f'Generating only {assets} assets in default formats for the target "{target.name()}".'
+        )
         project.generate(target.name(), asset_list=[assets], xmlid=xmlid)
+
 
 # pretext view
 
 
-@main.command(short_help="Preview specified target based on its format.",
-              context_settings=CONTEXT_SETTINGS)
-@click.argument('target', required=False)
+@main.command(
+    short_help="Preview specified target based on its format.",
+    context_settings=CONTEXT_SETTINGS,
+)
+@click.argument("target", required=False)
 @click.option(
-    '-a',
-    '--access',
-    type=click.Choice(['public', 'private'], case_sensitive=False),
-    default='private',
+    "-a",
+    "--access",
+    type=click.Choice(["public", "private"], case_sensitive=False),
+    default="private",
     show_default=True,
     help="""
     If running a local server,
     choose whether or not to allow other computers on your local network
     to access your documents using your IP address. (Ignored when used
     in CoCalc, which works automatically.)
-    """)
+    """,
+)
 @click.option(
-    '-p',
-    '--port',
+    "-p",
+    "--port",
     type=click.INT,
     help="""
     If running a local server,
     choose which port to use.
-    """)
+    """,
+)
 @click.option(
-    '-d',
-    '--directory',
+    "-d",
+    "--directory",
     type=click.Path(),
     help="""
     Run local server for provided directory (does not require a PreTeXt project)
-    """)
-@click.option('-w', '--watch', is_flag=True, help="""
+    """,
+)
+@click.option(
+    "-w",
+    "--watch",
+    is_flag=True,
+    help="""
     Run a build before starting server, and then
     watch the status of source files,
     automatically rebuilding target when changes
     are made. Only supports HTML-format targets, and
     only recommended for smaller projects or small
     subsets of projects.
-    """)
-@click.option('-b', '--build', is_flag=True, help="""
-    Run a build before viewing.
-    """)
-@click.option(
-    '-g', '--generate', is_flag=False, flag_value="ALL", default=None,
-    type=click.Choice(ASSETS, case_sensitive=False),
-    help='Generate all or specific assets before viewing')
-@click.option(
-    '--no-launch', is_flag=True,
-    help='By default, pretext view tries to launch the default application to view the specified target.  Setting this suppresses this behavior.'
+    """,
 )
-def view(target: str, access: str, port: Optional[int], directory: str, watch: bool, build: bool, generate: Optional[str], no_launch: bool):
+@click.option(
+    "-b",
+    "--build",
+    is_flag=True,
+    help="""
+    Run a build before viewing.
+    """,
+)
+@click.option(
+    "-g",
+    "--generate",
+    is_flag=False,
+    flag_value="ALL",
+    default=None,
+    type=click.Choice(ASSETS, case_sensitive=False),
+    help="Generate all or specific assets before viewing",
+)
+@click.option(
+    "--no-launch",
+    is_flag=True,
+    help="By default, pretext view tries to launch the default application to view the specified target.  Setting this suppresses this behavior.",
+)
+def view(
+    target: str,
+    access: str,
+    port: Optional[int],
+    directory: str,
+    watch: bool,
+    build: bool,
+    generate: Optional[str],
+    no_launch: bool,
+):
     """
     Starts a local server to preview built PreTeXt documents in your browser.
     TARGET is the name of the <target/> defined in `project.ptx`.
@@ -459,10 +572,12 @@ def view(target: str, access: str, port: Optional[int], directory: str, watch: b
 
 
 # pretext deploy
-@main.command(short_help="Deploys Git-managed project to GitHub Pages.",
-              context_settings=CONTEXT_SETTINGS)
-@click.argument('target', required=False)
-@click.option('-u', '--update_source', is_flag=True, required=False)
+@main.command(
+    short_help="Deploys Git-managed project to GitHub Pages.",
+    context_settings=CONTEXT_SETTINGS,
+)
+@click.argument("target", required=False)
+@click.option("-u", "--update_source", is_flag=True, required=False)
 def deploy(target, update_source):
     """
     Automatically deploys most recent build of [TARGET] to GitHub Pages,
@@ -480,7 +595,8 @@ def deploy(target, update_source):
         log.critical("Target could not be found in project.ptx manifest.")
         # only list targets with html format.
         log.critical(
-            f"Possible html targets to deploy are: {project.target_names('html')}")
+            f"Possible html targets to deploy are: {project.target_names('html')}"
+        )
         log.critical("Exiting without completing task.")
         return
     project.deploy(target_name, update_source)

--- a/pretext/core/__init__.py
+++ b/pretext/core/__init__.py
@@ -4,7 +4,8 @@ except ImportError as e:
     raise ImportError(
         "Failed to import the core pretext.py file. Perhaps the file is unavailable? "
         "Run `scripts/fetch_core.py` to grab a copy of pretex core.\n"
-        "The original error message is: " + e.msg)
+        "The original error message is: " + e.msg
+    )
 from . import resources
 
 set_ptx_path(resources.path())

--- a/pretext/core/resources.py
+++ b/pretext/core/resources.py
@@ -1,6 +1,8 @@
 from pathlib import Path
-import zipfile, importlib.resources
+import zipfile
+import importlib.resources
 from .. import CORE_COMMIT
+
 
 def path(*args) -> Path:
     # Checks that the local static path ~/.ptx/ contains the static files needed for core, and installs them if they are missing (or if the version is different from the installed version of pretext).  Then returns the absolute path to the static files (appending arguments)
@@ -17,12 +19,14 @@ def path(*args) -> Path:
         install(local_base_path)
     return local_base_path.joinpath(*args)
 
+
 def install(local_base_path):
-    with importlib.resources.path("pretext.core","resources.zip") as static_zip:
-        with zipfile.ZipFile(static_zip,"r") as zip:
+    with importlib.resources.path("pretext.core", "resources.zip") as static_zip:
+        with zipfile.ZipFile(static_zip, "r") as zip:
             zip.extractall(local_base_path)
     # Write the current commit to local file
-    with open(local_base_path/".commit","w") as f:
+    with open(local_base_path/".commit", "w") as f:
         f.write(CORE_COMMIT)
-    print(f"Static files required for pretext have now been installed to {local_base_path}")
+    print(
+        f"Static files required for pretext have now been installed to {local_base_path}")
     return

--- a/pretext/core/resources.py
+++ b/pretext/core/resources.py
@@ -6,8 +6,8 @@ from .. import CORE_COMMIT
 
 def path(*args) -> Path:
     # Checks that the local static path ~/.ptx/ contains the static files needed for core, and installs them if they are missing (or if the version is different from the installed version of pretext).  Then returns the absolute path to the static files (appending arguments)
-    local_base_path = Path.home()/'.ptx'
-    local_commit_file = Path(local_base_path)/".commit"
+    local_base_path = Path.home() / ".ptx"
+    local_commit_file = Path(local_base_path) / ".commit"
     if not Path.is_file(local_commit_file):
         print("Static pretext files do not appear to be installed.  Installing now.")
         install(local_base_path)
@@ -25,8 +25,9 @@ def install(local_base_path):
         with zipfile.ZipFile(static_zip, "r") as zip:
             zip.extractall(local_base_path)
     # Write the current commit to local file
-    with open(local_base_path/".commit", "w") as f:
+    with open(local_base_path / ".commit", "w") as f:
         f.write(CORE_COMMIT)
     print(
-        f"Static files required for pretext have now been installed to {local_base_path}")
+        f"Static files required for pretext have now been installed to {local_base_path}"
+    )
     return

--- a/pretext/generate.py
+++ b/pretext/generate.py
@@ -177,7 +177,7 @@ def asymptote(
                         stringparams=params,
                         xmlid_root=xmlid_root,
                         dest_dir=image_output.as_posix(),
-                        outformat=outformat ,
+                        outformat=outformat,
                         method="server",
                     )
             except Exception as e:

--- a/pretext/generate.py
+++ b/pretext/generate.py
@@ -6,36 +6,47 @@ from pathlib import Path
 from typing import Optional
 
 # Get access to logger
-log = logging.getLogger('ptxlogger')
+log = logging.getLogger("ptxlogger")
 
 # generate latex-image assets
 
 
-def latex_image(ptxfile: Path, pub_file: Path, output: Path, params, target_format, xmlid_root, pdf_method, all_formats=False):
+def latex_image(
+    ptxfile: Path,
+    pub_file: Path,
+    output: Path,
+    params,
+    target_format,
+    xmlid_root,
+    pdf_method,
+    all_formats=False,
+):
     # Dictionary of formats for images based on target
     formats = {
-        'pdf': None,
-        'latex':  None,
-        'html': ['svg'],
-        'epub': ['svg'],
-        'kindle': ['png'],
+        "pdf": None,
+        "latex": None,
+        "html": ["svg"],
+        "epub": ["svg"],
+        "kindle": ["png"],
     }
     # set overwrite formats to all when appropriate
     if all_formats:
-        formats[target_format] = {key: ['all']
-                                  for key in formats[target_format]}
+        formats[target_format] = {key: ["all"] for key in formats[target_format]}
     # We assume passed paths are absolute.
     # set images directory
     # parse source so we can check for latex-image.
     source_xml = ET.parse(ptxfile)
     for _ in range(20):
         source_xml.xinclude()
-    if len(source_xml.xpath("/pretext/*[not(docinfo)]//latex-image")) > 0 and formats[target_format] is not None:
-        image_output = (output/'latex-image').resolve()
+    if (
+        len(source_xml.xpath("/pretext/*[not(docinfo)]//latex-image")) > 0
+        and formats[target_format] is not None
+    ):
+        image_output = (output / "latex-image").resolve()
         os.makedirs(image_output, exist_ok=True)
-        log.info('Now generating latex-images\n\n')
+        log.info("Now generating latex-images\n\n")
         # Check for external requirements
-        utils.check_asset_execs('latex-image', formats[target_format])
+        utils.check_asset_execs("latex-image", formats[target_format])
         # call pretext-core's latex image module:
         with utils.working_directory(Path()):
             for outformat in formats[target_format]:
@@ -47,47 +58,58 @@ def latex_image(ptxfile: Path, pub_file: Path, output: Path, params, target_form
                         xmlid_root=xmlid_root,
                         dest_dir=image_output.as_posix(),
                         outformat=outformat,
-                        method=pdf_method
+                        method=pdf_method,
                     )
                 except Exception as e:
                     log.error(e)
-                    log.debug(
-                        f"Exception info:\n##################\n", exc_info=True)
-                    log.info('##################')
+                    log.debug(f"Exception info:\n##################\n", exc_info=True)
+                    log.info("##################")
                     log.error(
-                        'Failed to generate some latex-image elements.  Check your source and partial output to diagnose the issue.')
-                    log.warning('Continuing...')
+                        "Failed to generate some latex-image elements.  Check your source and partial output to diagnose the issue."
+                    )
+                    log.warning("Continuing...")
     else:
         log.info("Note: No latex-image elements found.")
+
 
 # generate sageplot assets
 
 
-def sageplot(ptxfile: Path, pub_file: Path, output: Path, params, target_format, xmlid_root, all_formats=False):
+def sageplot(
+    ptxfile: Path,
+    pub_file: Path,
+    output: Path,
+    params,
+    target_format,
+    xmlid_root,
+    all_formats=False,
+):
     # Dictionary of formats for images based on target
     formats = {
-        'pdf': ['pdf', 'png'],
-        'latex':  ['pdf', 'png'],
-        'html': ['html', 'svg'],
-        'epub': ['svg'],
-        'kindle': ['png'],
+        "pdf": ["pdf", "png"],
+        "latex": ["pdf", "png"],
+        "html": ["html", "svg"],
+        "epub": ["svg"],
+        "kindle": ["png"],
     }
     # set overwrite formats to all when appropriate
     if all_formats:
-        formats[target_format] = {key: ['all']
-                                  for key in formats[target_format]}
+        formats[target_format] = {key: ["all"] for key in formats[target_format]}
     # We assume passed paths are absolute.
     # set images directory
     # parse source so we can check for sageplot.
     source_xml = ET.parse(ptxfile)
     for _ in range(20):
         source_xml.xinclude()
-    if len(source_xml.xpath("/pretext/*[not(docinfo)]//sageplot")) > 0 and formats[target_format] is not None:
-        image_output = (output/'sageplot').resolve()
+    if (
+        len(source_xml.xpath("/pretext/*[not(docinfo)]//sageplot")) > 0
+        and formats[target_format] is not None
+    ):
+        image_output = (output / "sageplot").resolve()
         os.makedirs(image_output, exist_ok=True)
-        log.info('Now generating sageplot images\n\n')
+        log.info("Now generating sageplot images\n\n")
         # Check for external requirements
-        utils.check_asset_execs('sageplot', formats[target_format])
+        utils.check_asset_execs("sageplot", formats[target_format])
         with utils.working_directory(Path()):
             try:
                 for outformat in formats[target_format]:
@@ -97,44 +119,55 @@ def sageplot(ptxfile: Path, pub_file: Path, output: Path, params, target_format,
                         stringparams=params,
                         xmlid_root=xmlid_root,
                         dest_dir=image_output.as_posix(),
-                        outformat=outformat
+                        outformat=outformat,
                     )
             except Exception as e:
                 log.error(e)
-                log.debug(f"Exception info:\n##################\n",
-                          exc_info=True)
-                log.info('##################')
+                log.debug(f"Exception info:\n##################\n", exc_info=True)
+                log.info("##################")
                 log.error(
-                    'Failed to generate some sageplot elements.  Check your source and partial output to diagnose the issue.')
-                log.warning('Continuing...')
+                    "Failed to generate some sageplot elements.  Check your source and partial output to diagnose the issue."
+                )
+                log.warning("Continuing...")
     else:
         log.info("Note: No sageplot elements found.")
+
 
 # generate asymptote assets
 
 
-def asymptote(ptxfile: Path, pub_file: Path, output: Path, params, target_format, xmlid_root, all_formats=False):
+def asymptote(
+    ptxfile: Path,
+    pub_file: Path,
+    output: Path,
+    params,
+    target_format,
+    xmlid_root,
+    all_formats=False,
+):
     # Dictionary of formats for images based on target
     formats = {
-        'pdf': ['pdf'],
-        'latex':  ['pdf'],
-        'html': ['html'],
-        'epub': ['svg'],
-        'kindle': ['png'],
+        "pdf": ["pdf"],
+        "latex": ["pdf"],
+        "html": ["html"],
+        "epub": ["svg"],
+        "kindle": ["png"],
     }
     # set overwrite formats to all when appropriate
     if all_formats:
-        formats[target_format] = {key: ['all']
-                                  for key in formats[target_format]}
+        formats[target_format] = {key: ["all"] for key in formats[target_format]}
     # We assume passed paths are absolute.
     # parse source so we can check for asymptote.
     source_xml = ET.parse(ptxfile)
     for _ in range(20):
         source_xml.xinclude()
-    if len(source_xml.xpath("/pretext/*[not(docinfo)]//asymptote")) > 0 and formats[target_format] is not None:
-        image_output = (output/'asymptote').resolve()
+    if (
+        len(source_xml.xpath("/pretext/*[not(docinfo)]//asymptote")) > 0
+        and formats[target_format] is not None
+    ):
+        image_output = (output / "asymptote").resolve()
         os.makedirs(image_output, exist_ok=True)
-        log.info('Now generating asymptote images\n\n')
+        log.info("Now generating asymptote images\n\n")
         with utils.working_directory(Path()):
             try:
                 for outformat in formats[target_format]:
@@ -144,19 +177,20 @@ def asymptote(ptxfile: Path, pub_file: Path, output: Path, params, target_format
                         stringparams=params,
                         xmlid_root=xmlid_root,
                         dest_dir=image_output.as_posix(),
-                        outformat=outformat,
-                        method='server'
+                        outformat=outformat ,
+                        method="server",
                     )
             except Exception as e:
                 log.error(e)
-                log.debug(f"Exception info:\n##################\n",
-                          exc_info=True)
-                log.info('##################')
+                log.debug(f"Exception info:\n##################\n", exc_info=True)
+                log.info("##################")
                 log.error(
-                    'Failed to generate some asymptote elements. Check your source and partial output to diagnose the issue.')
-                log.warning('Continuing...')
+                    "Failed to generate some asymptote elements. Check your source and partial output to diagnose the issue."
+                )
+                log.warning("Continuing...")
     else:
         log.info("Note: No asymptote elements found.")
+
 
 # generate interactive preview assets
 
@@ -170,9 +204,9 @@ def interactive(ptxfile: Path, pub_file: Path, output: Path, params, xmlid_root)
     for _ in range(20):
         source_xml.xinclude()
     if len(source_xml.xpath("/pretext/*[not(docinfo)]//interactive")) > 0:
-        image_output = (output/'preview').resolve()
+        image_output = (output / "preview").resolve()
         os.makedirs(image_output, exist_ok=True)
-        log.info('Now generating preview images for interactives\n\n')
+        log.info("Now generating preview images for interactives\n\n")
         with utils.working_directory(Path()):
             try:
                 core.preview_images(
@@ -184,14 +218,15 @@ def interactive(ptxfile: Path, pub_file: Path, output: Path, params, xmlid_root)
                 )
             except Exception as e:
                 log.error(
-                    "Failed to generate interactive element previews. Check debug log for info.")
+                    "Failed to generate interactive element previews. Check debug log for info."
+                )
                 log.debug(e)
-                log.debug(f"Exception info:\n##################\n",
-                          exc_info=True)
-                log.info('##################')
-                log.warning('Continuing...')
+                log.debug(f"Exception info:\n##################\n", exc_info=True)
+                log.info("##################")
+                log.warning("Continuing...")
     else:
         log.info("Note: No interactive elements found.")
+
 
 # generate youtube thumbnail assets
 
@@ -203,9 +238,9 @@ def youtube(ptxfile: Path, pub_file: Path, output: Path, params, xmlid_root):
     for _ in range(20):
         source_xml.xinclude()
     if len(source_xml.xpath("/pretext/*[not(docinfo)]//video[@youtube]")) > 0:
-        image_output = (output/'youtube').resolve()
+        image_output = (output / "youtube").resolve()
         os.makedirs(image_output, exist_ok=True)
-        log.info('Now generating youtube previews\n\n')
+        log.info("Now generating youtube previews\n\n")
         with utils.working_directory(Path()):
             try:
                 core.youtube_thumbnail(
@@ -217,14 +252,15 @@ def youtube(ptxfile: Path, pub_file: Path, output: Path, params, xmlid_root):
                 )
             except Exception as e:
                 log.error(e)
-                log.debug(f"Exception info:\n##################\n",
-                          exc_info=True)
-                log.info('##################')
+                log.debug(f"Exception info:\n##################\n", exc_info=True)
+                log.info("##################")
                 log.error(
-                    'Failed to generate some youtube video previews. Check your source and partial output to diagnose the issue.')
-                log.warning('Continuing...')
+                    "Failed to generate some youtube video previews. Check your source and partial output to diagnose the issue."
+                )
+                log.warning("Continuing...")
     else:
         log.info("Note: No video@youtube elements found.")
+
 
 # generate webwork assets
 
@@ -235,10 +271,10 @@ def webwork(ptxfile: Path, pub_file: Path, output: Path, params, xmlid_root=None
     source_xml = ET.parse(ptxfile)
     for _ in range(20):
         source_xml.xinclude()
-    if len(source_xml.xpath('//webwork[node()|@*]')) > 0:
-        ww_output = (output/'webwork').resolve()
+    if len(source_xml.xpath("//webwork[node()|@*]")) > 0:
+        ww_output = (output / "webwork").resolve()
         os.makedirs(ww_output, exist_ok=True)
-        log.info('Now generating webwork representation\n\n')
+        log.info("Now generating webwork representation\n\n")
         with utils.working_directory(Path()):
             try:
                 core.webwork_to_xml(
@@ -252,14 +288,15 @@ def webwork(ptxfile: Path, pub_file: Path, output: Path, params, xmlid_root=None
                 )
             except Exception as e:
                 log.error(e)
-                log.debug(f"Exception info:\n##################\n",
-                          exc_info=True)
-                log.info('##################')
+                log.debug(f"Exception info:\n##################\n", exc_info=True)
+                log.info("##################")
                 log.error(
-                    'Failed to generate the webwork-representations file.  Check your source and partial output to diagnose the issue.')
-                log.warning('Continuing...')
+                    "Failed to generate the webwork-representations file.  Check your source and partial output to diagnose the issue."
+                )
+                log.warning("Continuing...")
     else:
         log.info("Note: No webwork elements found.")
+
 
 # generate codelens trace assets
 
@@ -271,9 +308,9 @@ def codelens(ptxfile: Path, pub_file: Path, output: Path, params, xmlid_root):
     for _ in range(20):
         source_xml.xinclude()
     if len(source_xml.xpath("//program[@interactive = 'codelens']")) > 0:
-        trace_output = (output/'trace').resolve()
+        trace_output = (output / "trace").resolve()
         os.makedirs(trace_output, exist_ok=True)
-        log.info('Now generating codelens trace\n\n')
+        log.info("Now generating codelens trace\n\n")
         with utils.working_directory(Path()):
             try:
                 core.tracer(
@@ -285,10 +322,9 @@ def codelens(ptxfile: Path, pub_file: Path, output: Path, params, xmlid_root):
                 )
             except Exception as e:
                 log.error(e)
-                log.debug(f"Exception info:\n##################\n",
-                          exc_info=True)
-                log.info('##################')
-                log.error('Failed to generate codelens trace.')
-                log.warning('Continuing...')
+                log.debug(f"Exception info:\n##################\n", exc_info=True)
+                log.info("##################")
+                log.error("Failed to generate codelens trace.")
+                log.warning("Continuing...")
     else:
         log.info("Note: No program elements using codelens found.")

--- a/pretext/generate.py
+++ b/pretext/generate.py
@@ -9,7 +9,9 @@ from typing import Optional
 log = logging.getLogger('ptxlogger')
 
 # generate latex-image assets
-def latex_image(ptxfile:Path, pub_file:Path, output:Path, params, target_format, xmlid_root, pdf_method, all_formats=False):
+
+
+def latex_image(ptxfile: Path, pub_file: Path, output: Path, params, target_format, xmlid_root, pdf_method, all_formats=False):
     # Dictionary of formats for images based on target
     formats = {
         'pdf': None,
@@ -20,7 +22,8 @@ def latex_image(ptxfile:Path, pub_file:Path, output:Path, params, target_format,
     }
     # set overwrite formats to all when appropriate
     if all_formats:
-        formats[target_format] = {key: ['all'] for key in formats[target_format]}
+        formats[target_format] = {key: ['all']
+                                  for key in formats[target_format]}
     # We assume passed paths are absolute.
     # set images directory
     # parse source so we can check for latex-image.
@@ -38,36 +41,41 @@ def latex_image(ptxfile:Path, pub_file:Path, output:Path, params, target_format,
             for outformat in formats[target_format]:
                 try:
                     core.latex_image_conversion(
-                        xml_source=ptxfile, 
-                        pub_file=pub_file.as_posix(), 
+                        xml_source=ptxfile,
+                        pub_file=pub_file.as_posix(),
                         stringparams=params,
-                        xmlid_root=xmlid_root, 
-                        dest_dir=image_output.as_posix(), 
-                        outformat=outformat, 
+                        xmlid_root=xmlid_root,
+                        dest_dir=image_output.as_posix(),
+                        outformat=outformat,
                         method=pdf_method
                     )
                 except Exception as e:
                     log.error(e)
-                    log.debug(f"Exception info:\n##################\n", exc_info=True)
+                    log.debug(
+                        f"Exception info:\n##################\n", exc_info=True)
                     log.info('##################')
-                    log.error('Failed to generate some latex-image elements.  Check your source and partial output to diagnose the issue.')
+                    log.error(
+                        'Failed to generate some latex-image elements.  Check your source and partial output to diagnose the issue.')
                     log.warning('Continuing...')
     else:
         log.info("Note: No latex-image elements found.")
 
 # generate sageplot assets
-def sageplot(ptxfile:Path, pub_file:Path, output:Path, params, target_format, xmlid_root, all_formats=False):
+
+
+def sageplot(ptxfile: Path, pub_file: Path, output: Path, params, target_format, xmlid_root, all_formats=False):
     # Dictionary of formats for images based on target
     formats = {
-        'pdf': ['pdf','png'],
-        'latex':  ['pdf','png'],
-        'html': ['html','svg'],
+        'pdf': ['pdf', 'png'],
+        'latex':  ['pdf', 'png'],
+        'html': ['html', 'svg'],
         'epub': ['svg'],
         'kindle': ['png'],
     }
     # set overwrite formats to all when appropriate
     if all_formats:
-        formats[target_format] = {key: ['all'] for key in formats[target_format]}
+        formats[target_format] = {key: ['all']
+                                  for key in formats[target_format]}
     # We assume passed paths are absolute.
     # set images directory
     # parse source so we can check for sageplot.
@@ -93,15 +101,19 @@ def sageplot(ptxfile:Path, pub_file:Path, output:Path, params, target_format, xm
                     )
             except Exception as e:
                 log.error(e)
-                log.debug(f"Exception info:\n##################\n", exc_info=True)
+                log.debug(f"Exception info:\n##################\n",
+                          exc_info=True)
                 log.info('##################')
-                log.error('Failed to generate some sageplot elements.  Check your source and partial output to diagnose the issue.')
+                log.error(
+                    'Failed to generate some sageplot elements.  Check your source and partial output to diagnose the issue.')
                 log.warning('Continuing...')
     else:
         log.info("Note: No sageplot elements found.")
 
 # generate asymptote assets
-def asymptote(ptxfile:Path, pub_file:Path, output:Path, params, target_format, xmlid_root, all_formats=False):
+
+
+def asymptote(ptxfile: Path, pub_file: Path, output: Path, params, target_format, xmlid_root, all_formats=False):
     # Dictionary of formats for images based on target
     formats = {
         'pdf': ['pdf'],
@@ -112,7 +124,8 @@ def asymptote(ptxfile:Path, pub_file:Path, output:Path, params, target_format, x
     }
     # set overwrite formats to all when appropriate
     if all_formats:
-        formats[target_format] = {key: ['all'] for key in formats[target_format]}
+        formats[target_format] = {key: ['all']
+                                  for key in formats[target_format]}
     # We assume passed paths are absolute.
     # parse source so we can check for asymptote.
     source_xml = ET.parse(ptxfile)
@@ -136,15 +149,19 @@ def asymptote(ptxfile:Path, pub_file:Path, output:Path, params, target_format, x
                     )
             except Exception as e:
                 log.error(e)
-                log.debug(f"Exception info:\n##################\n", exc_info=True)
+                log.debug(f"Exception info:\n##################\n",
+                          exc_info=True)
                 log.info('##################')
-                log.error('Failed to generate some asymptote elements. Check your source and partial output to diagnose the issue.')
+                log.error(
+                    'Failed to generate some asymptote elements. Check your source and partial output to diagnose the issue.')
                 log.warning('Continuing...')
     else:
         log.info("Note: No asymptote elements found.")
 
 # generate interactive preview assets
-def interactive(ptxfile:Path, pub_file:Path, output:Path, params, xmlid_root):
+
+
+def interactive(ptxfile: Path, pub_file: Path, output: Path, params, xmlid_root):
     log.warning("Interactive preview generation is temporarily unavailable.")
     return
     # We assume passed paths are absolute.
@@ -166,16 +183,20 @@ def interactive(ptxfile:Path, pub_file:Path, output:Path, params, xmlid_root):
                     dest_dir=image_output.as_posix(),
                 )
             except Exception as e:
-                log.error("Failed to generate interactive element previews. Check debug log for info.")
+                log.error(
+                    "Failed to generate interactive element previews. Check debug log for info.")
                 log.debug(e)
-                log.debug(f"Exception info:\n##################\n", exc_info=True)
+                log.debug(f"Exception info:\n##################\n",
+                          exc_info=True)
                 log.info('##################')
                 log.warning('Continuing...')
     else:
         log.info("Note: No interactive elements found.")
 
 # generate youtube thumbnail assets
-def youtube(ptxfile:Path, pub_file:Path, output:Path, params, xmlid_root):
+
+
+def youtube(ptxfile: Path, pub_file: Path, output: Path, params, xmlid_root):
     # We assume passed paths are absolute.
     # parse source so we can check for videos.
     source_xml = ET.parse(ptxfile)
@@ -196,15 +217,19 @@ def youtube(ptxfile:Path, pub_file:Path, output:Path, params, xmlid_root):
                 )
             except Exception as e:
                 log.error(e)
-                log.debug(f"Exception info:\n##################\n", exc_info=True)
+                log.debug(f"Exception info:\n##################\n",
+                          exc_info=True)
                 log.info('##################')
-                log.error('Failed to genereate some youtube video previews. Check your source and partial output to diagnose the issue.')
+                log.error(
+                    'Failed to generate some youtube video previews. Check your source and partial output to diagnose the issue.')
                 log.warning('Continuing...')
     else:
         log.info("Note: No video@youtube elements found.")
 
 # generate webwork assets
-def webwork(ptxfile:Path, pub_file:Path, output:Path, params, xmlid_root=None):
+
+
+def webwork(ptxfile: Path, pub_file: Path, output: Path, params, xmlid_root=None):
     # We assume passed paths are absolute.
     # parse source so we can check for webwork.
     source_xml = ET.parse(ptxfile)
@@ -227,15 +252,19 @@ def webwork(ptxfile:Path, pub_file:Path, output:Path, params, xmlid_root=None):
                 )
             except Exception as e:
                 log.error(e)
-                log.debug(f"Exception info:\n##################\n", exc_info=True)
+                log.debug(f"Exception info:\n##################\n",
+                          exc_info=True)
                 log.info('##################')
-                log.error('Failed to generate the webwork-representations file.  Check your source and partial output to diagnose the issue.')
+                log.error(
+                    'Failed to generate the webwork-representations file.  Check your source and partial output to diagnose the issue.')
                 log.warning('Continuing...')
     else:
         log.info("Note: No webwork elements found.")
 
 # generate codelens trace assets
-def codelens(ptxfile:Path, pub_file:Path, output:Path, params, xmlid_root):
+
+
+def codelens(ptxfile: Path, pub_file: Path, output: Path, params, xmlid_root):
     # We assume passed paths are absolute.
     # parse source so we can check for webwork.
     source_xml = ET.parse(ptxfile)
@@ -256,7 +285,8 @@ def codelens(ptxfile:Path, pub_file:Path, output:Path, params, xmlid_root):
                 )
             except Exception as e:
                 log.error(e)
-                log.debug(f"Exception info:\n##################\n", exc_info=True)
+                log.debug(f"Exception info:\n##################\n",
+                          exc_info=True)
                 log.info('##################')
                 log.error('Failed to generate codelens trace.')
                 log.warning('Continuing...')

--- a/pretext/project.py
+++ b/pretext/project.py
@@ -12,10 +12,10 @@ import sys
 from typing import Optional
 import webbrowser
 
-log = logging.getLogger('ptxlogger')
+log = logging.getLogger("ptxlogger")
 
 
-class Target():
+class Target:
     def __init__(self, xml_element, project_path):
         # construction is done!
         self.__xml_element = xml_element
@@ -46,7 +46,7 @@ class Target():
         return self.xml_element().find("format").text.strip()
 
     def source(self) -> Path:
-        return (self.project_path()/self.xml_element().find("source").text.strip())
+        return self.project_path() / self.xml_element().find("source").text.strip()
 
     def source_dir(self) -> Path:
         return Path(self.source()).parent
@@ -57,7 +57,7 @@ class Target():
         return ele_tree.getroot()
 
     def publication(self) -> Path:
-        return (self.project_path()/self.xml_element().find("publication").text.strip())
+        return self.project_path() / self.xml_element().find("publication").text.strip()
 
     def publication_dir(self) -> Path:
         return self.publication().parent
@@ -76,7 +76,7 @@ class Target():
             log.error("Publication file does not specify asset directories.")
             return None
         rel_dir = dir_ele.get("external")
-        return self.source_dir()/rel_dir
+        return self.source_dir() / rel_dir
 
     def generated_dir(self) -> Optional[Path]:
         dir_ele = self.publication_xml().find("source/directories")
@@ -84,10 +84,13 @@ class Target():
             log.error("Publication file does not specify asset directories.")
             return None
         rel_dir = dir_ele.get("generated")
-        return self.source_dir()/rel_dir
+        return self.source_dir() / rel_dir
 
     def output_dir(self) -> Path:
-        return (Path(self.__project_path)/self.xml_element().find("output-dir").text.strip()).resolve()
+        return (
+            Path(self.__project_path)
+            / self.xml_element().find("output-dir").text.strip()
+        ).resolve()
 
     def output_filename(self) -> Optional[str]:
         if self.xml_element().find("output-filename") is None:
@@ -110,7 +113,9 @@ class Target():
 
     def xsl_path(self) -> Optional[Path]:
         if self.xml_element().find("xsl") is not None:
-            return (Path(self.__project_path)/self.xml_element().find("xsl").text.strip()).resolve()
+            return (
+                Path(self.__project_path) / self.xml_element().find("xsl").text.strip()
+            ).resolve()
         else:
             return None
 
@@ -122,10 +127,10 @@ class Target():
             return ele.text.strip()
 
 
-class Project():
+class Project:
     def __init__(self, project_path=None):
         project_path = project_path or utils.project_path()
-        xml_element = ET.parse(project_path/"project.ptx").getroot()
+        xml_element = ET.parse(project_path / "project.ptx").getroot()
         self.__xml_element = xml_element
         self.__project_path = project_path
         # prepre core PreTeXt python scripts
@@ -136,8 +141,7 @@ class Project():
 
     def targets(self):
         return [
-            Target(xml_element=target_element,
-                   project_path=self.__project_path)
+            Target(xml_element=target_element, project_path=self.__project_path)
             for target_element in self.xml_element().xpath("targets/target")
         ]
 
@@ -157,14 +161,20 @@ class Project():
         if name is None:
             target_element = self.xml_element().find("targets/target")
         else:
-            target_element = self.xml_element().find(
-                f'targets/target[@name="{name}"]')
+            target_element = self.xml_element().find(f'targets/target[@name="{name}"]')
         if target_element is not None:
             return Target(xml_element=target_element, project_path=self.__project_path)
         else:
             return None
 
-    def view(self, target_name: str, access: str, port: int, watch: bool = False, no_launch: bool = False):
+    def view(
+        self,
+        target_name: str,
+        access: str,
+        port: int,
+        watch: bool = False,
+        no_launch: bool = False,
+    ):
         target = self.target(target_name)
         directory = target.output_dir()
         if watch:
@@ -174,19 +184,24 @@ class Project():
         if not target.output_dir().exists():
             log.error(f"The directory `{target.output_dir()}` does not exist.")
             log.error(
-                f"Run `pretext view {target.name()} -b` to build your project before viewing.")
+                f"Run `pretext view {target.name()} -b` to build your project before viewing."
+            )
             return
 
-        def watch_callback(): return self.build(target_name)
+        def watch_callback():
+            return self.build(target_name)
+
         if utils.cocalc_project_id() is not None:
-            if target.format() in ['html', 'pdf']:
-                utils.run_server(directory, access, port,
-                                 watch_directory, watch_callback, no_launch)
+            if target.format() in ["html", "pdf"]:
+                utils.run_server(
+                    directory, access, port, watch_directory, watch_callback, no_launch
+                )
             else:
                 log.info(f"Output can be viewed by navigating to {directory}")
-        elif target.format() == 'html':
-            utils.run_server(directory, access, port,
-                             watch_directory, watch_callback, no_launch)
+        elif target.format() == "html":
+            utils.run_server(
+                directory, access, port, watch_directory, watch_callback, no_launch
+            )
         else:
             outputfiles = list(Path(directory).glob("*.*"))
             log.info(f"Output can be viewed by navigating to {directory}")
@@ -197,7 +212,8 @@ class Project():
                     outputfile = str(outputfiles[0])
                     webbrowser.open(outputfile)
                     log.info(
-                        f"Attempting to open output using default viewer for {target.format()} files.  If this doesn't work, you can open {outputfile} manually.")
+                        f"Attempting to open output using default viewer for {target.format()} files.  If this doesn't work, you can open {outputfile} manually."
+                    )
                 except:
                     return
 
@@ -214,78 +230,132 @@ class Project():
             # refuse to clean if output is not a subdirectory of the working directory or contains source/publication
             if Path(self.__project_path) not in target.output_dir().parents:
                 log.warning(
-                    "Refusing to clean output directory that isn't a proper subdirectory of the project.")
-            elif target.output_dir() in (target.source_dir()/"foo").parents or \
-                    target.output_dir() in (target.publication_dir()/"foo").parents:
+                    "Refusing to clean output directory that isn't a proper subdirectory of the project."
+                )
+            elif (
+                target.output_dir() in (target.source_dir() / "foo").parents
+                or target.output_dir() in (target.publication_dir() / "foo").parents
+            ):
                 log.warning(
-                    "Refusing to clean output directory that contains source or publication files.")
+                    "Refusing to clean output directory that contains source or publication files."
+                )
             # handle request to clean directory that does not exist
             elif not target.output_dir().exists():
                 log.warning(
-                    f"Directory {target.output_dir()} already does not exist, nothing to clean.")
+                    f"Directory {target.output_dir()} already does not exist, nothing to clean."
+                )
             else:
                 log.warning(
-                    f"Destroying directory {target.output_dir()} to clean previously built files.")
+                    f"Destroying directory {target.output_dir()} to clean previously built files."
+                )
                 shutil.rmtree(target.output_dir())
         # if custom xsl, copy it into a temporary directory (different from the building temporary directory)
         custom_xsl = None
         if target.xsl_path() is not None:
             temp_xsl_path = Path(tempfile.mkdtemp())
             log.info(
-                f'Building with custom xsl {target.xsl_path()} specified in project.ptx')
+                f"Building with custom xsl {target.xsl_path()} specified in project.ptx"
+            )
             utils.copy_custom_xsl(target.xsl_path(), temp_xsl_path)
-            custom_xsl = temp_xsl_path/target.xsl_path().name
+            custom_xsl = temp_xsl_path / target.xsl_path().name
         # warn if "publisher" is one of the string-param keys:
-        if 'publisher' in target.stringparams():
-            log.warning('You specified a publication file via a stringparam.  This is ignored in favor of the publication file given by the <publication> element in the project manifest.')
+        if "publisher" in target.stringparams():
+            log.warning(
+                "You specified a publication file via a stringparam.  This is ignored in favor of the publication file given by the <publication> element in the project manifest."
+            )
         log.info(f"Preparing to build into {target.output_dir()}.")
         try:
-            if (target.format() == 'html' or target.format() == 'html-zip'):
-                zipped = (target.format() == 'html-zip')
-                builder.html(target.source(), target.publication(), target.output_dir(
-                ), target.stringparams(), custom_xsl, target.xmlid_root(), zipped)
-            elif target.format() == 'latex':
-                builder.latex(target.source(), target.publication(
-                ), target.output_dir(), target.stringparams(), custom_xsl)
+            if target.format() == "html" or target.format() == "html-zip":
+                zipped = target.format() == "html-zip"
+                builder.html(
+                    target.source(),
+                    target.publication(),
+                    target.output_dir(),
+                    target.stringparams(),
+                    custom_xsl,
+                    target.xmlid_root(),
+                    zipped,
+                )
+            elif target.format() == "latex":
+                builder.latex(
+                    target.source(),
+                    target.publication(),
+                    target.output_dir(),
+                    target.stringparams(),
+                    custom_xsl,
+                )
                 # core script doesn't put a copy of images in output for latex builds, so we do it instead here
-                shutil.copytree(target.external_dir(
-                ), target.output_dir()/"external", dirs_exist_ok=True)
-                shutil.copytree(target.generated_dir(
-                ), target.output_dir()/"generated", dirs_exist_ok=True)
-            elif target.format() == 'pdf':
-                builder.pdf(target.source(), target.publication(), target.output_dir(
-                ), target.stringparams(), custom_xsl, target.pdf_method())
-            elif target.format() == 'custom':
+                shutil.copytree(
+                    target.external_dir(),
+                    target.output_dir() / "external",
+                    dirs_exist_ok=True,
+                )
+                shutil.copytree(
+                    target.generated_dir(),
+                    target.output_dir() / "generated",
+                    dirs_exist_ok=True,
+                )
+            elif target.format() == "pdf":
+                builder.pdf(
+                    target.source(),
+                    target.publication(),
+                    target.output_dir(),
+                    target.stringparams(),
+                    custom_xsl,
+                    target.pdf_method(),
+                )
+            elif target.format() == "custom":
                 if custom_xsl is None:
-                    raise Exception(
-                        "Must specify custom XSL for custom build.")
-                builder.custom(target.source(), target.publication(), target.output_dir(
-                ), target.stringparams(), custom_xsl, target.output_filename())
-            elif target.format() == 'epub':
-                builder.epub(target.source(), target.publication(),
-                             target.output_dir(), target.stringparams())
-            elif target.format() == 'kindle':
-                builder.kindle(target.source(), target.publication(
-                ), target.output_dir(), target.stringparams())
-            elif target.format() == 'braille' or target.format() == 'braille-emboss':
-                builder.braille(target.source(), target.publication(
-                ), target.output_dir(), target.stringparams(), page_format="emboss")
-            elif target.format() == 'braille-electronic':
-                builder.braille(target.source(), target.publication(
-                ), target.output_dir(), target.stringparams(), page_format="electronic")
+                    raise Exception("Must specify custom XSL for custom build.")
+                builder.custom(
+                    target.source(),
+                    target.publication(),
+                    target.output_dir(),
+                    target.stringparams(),
+                    custom_xsl,
+                    target.output_filename(),
+                )
+            elif target.format() == "epub":
+                builder.epub(
+                    target.source(),
+                    target.publication(),
+                    target.output_dir(),
+                    target.stringparams(),
+                )
+            elif target.format() == "kindle":
+                builder.kindle(
+                    target.source(),
+                    target.publication(),
+                    target.output_dir(),
+                    target.stringparams(),
+                )
+            elif target.format() == "braille" or target.format() == "braille-emboss":
+                builder.braille(
+                    target.source(),
+                    target.publication(),
+                    target.output_dir(),
+                    target.stringparams(),
+                    page_format="emboss",
+                )
+            elif target.format() == "braille-electronic":
+                builder.braille(
+                    target.source(),
+                    target.publication(),
+                    target.output_dir(),
+                    target.stringparams(),
+                    page_format="electronic",
+                )
             else:
-                log.critical(
-                    f'The build format {target.format()} is not supported.')
+                log.critical(f"The build format {target.format()} is not supported.")
         except Exception as e:
             log.critical(
-                f"A fatal error has occurred:\n {e} \nFor more info, run pretext with `-v debug`")
+                f"A fatal error has occurred:\n {e} \nFor more info, run pretext with `-v debug`"
+            )
             log.debug(f"Exception info:\n##################\n", exc_info=True)
-            log.info('##################')
-            sys.exit(
-                f"Failed to build pretext target {target.format()}.  Exiting...")
+            log.info("##################")
+            sys.exit(f"Failed to build pretext target {target.format()}.  Exiting...")
         # build was successful
-        log.info(
-            f"\nSuccess! Run `pretext view {target.name()}` to see the results.\n")
+        log.info(f"\nSuccess! Run `pretext view {target.name()}` to see the results.\n")
         if custom_xsl is not None:
             # errors may occur in Windows so we do the best we can
             shutil.rmtree(custom_xsl.parent, ignore_errors=True)
@@ -303,38 +373,67 @@ class Project():
             return
         # build targets:
         if gen_all or "webwork" in asset_list:
-            webwork_output = target.generated_dir()/'webwork'
+            webwork_output = target.generated_dir() / "webwork"
             generate.webwork(
-                target.source(), target.publication(), webwork_output, target.stringparams(), xmlid,
+                target.source(),
+                target.publication(),
+                webwork_output,
+                target.stringparams(),
+                xmlid,
             )
         if gen_all or "latex-image" in asset_list:
             generate.latex_image(
-                target.source(), target.publication(), target.generated_dir(), target.stringparams(),
-                target.format(), xmlid, target.pdf_method(), all_formats
+                target.source(),
+                target.publication(),
+                target.generated_dir(),
+                target.stringparams(),
+                target.format(),
+                xmlid,
+                target.pdf_method(),
+                all_formats,
             )
         if gen_all or "asymptote" in asset_list:
             generate.asymptote(
-                target.source(), target.publication(), target.generated_dir(), target.stringparams(),
-                target.format(), xmlid, all_formats
+                target.source(),
+                target.publication(),
+                target.generated_dir(),
+                target.stringparams(),
+                target.format(),
+                xmlid,
+                all_formats,
             )
         if gen_all or "sageplot" in asset_list:
             generate.sageplot(
-                target.source(), target.publication(), target.generated_dir(), target.stringparams(),
-                target.format(), xmlid, all_formats
+                target.source(),
+                target.publication(),
+                target.generated_dir(),
+                target.stringparams(),
+                target.format(),
+                xmlid,
+                all_formats,
             )
         if gen_all or "interactive" in asset_list:
             generate.interactive(
-                target.source(), target.publication(), target.generated_dir(), target.stringparams(),
+                target.source(),
+                target.publication(),
+                target.generated_dir(),
+                target.stringparams(),
                 xmlid,
             )
         if gen_all or "youtube" in asset_list:
             generate.youtube(
-                target.source(), target.publication(), target.generated_dir(), target.stringparams(),
+                target.source(),
+                target.publication(),
+                target.generated_dir(),
+                target.stringparams(),
                 xmlid,
             )
         if gen_all or "codelens" in asset_list:
             generate.codelens(
-                target.source(), target.publication(), target.generated_dir(), target.stringparams(),
+                target.source(),
+                target.publication(),
+                target.generated_dir(),
+                target.stringparams(),
                 xmlid,
             )
 
@@ -344,9 +443,9 @@ class Project():
             import ghp_import
         except ImportError:
             log.error(
-                "Git must be installed to use this feature, but couldn't be found.")
-            log.error(
-                "Visit https://github.com/git-guides/install-git for assistance.")
+                "Git must be installed to use this feature, but couldn't be found."
+            )
+            log.error("Visit https://github.com/git-guides/install-git for assistance.")
             return
         target = self.target(target_name)
         if target.format() != "html":  # redundant for CLI
@@ -373,7 +472,8 @@ class Project():
             log.info("Successfully initialized new Git repository!")
             log.info("")
         log.info(
-            f"Preparing to deploy from active `{repo.active_branch.name}` git branch.")
+            f"Preparing to deploy from active `{repo.active_branch.name}` git branch."
+        )
         log.info("")
         if repo.bare or repo.is_dirty() or len(repo.untracked_files) > 0:
             log.info("Changes to project source since last commit detected.")
@@ -385,13 +485,16 @@ class Project():
             else:
                 log.error("Either add and commit these changes with Git, or run")
                 log.error(
-                    "`pretext deploy -u` to have these changes updated automatically.")
+                    "`pretext deploy -u` to have these changes updated automatically."
+                )
                 return
         if not target.output_dir().exists():
             log.error(
-                f"No build for `{target.name()}` was found in the directory `{target.output_dir()}`.")
+                f"No build for `{target.name()}` was found in the directory `{target.output_dir()}`."
+            )
             log.error(
-                f"Try running `pretext view {target.name()} -b` to build and preview your project first.")
+                f"Try running `pretext view {target.name()} -b` to build and preview your project first."
+            )
             return
         log.info(f"Using latest build located in `{target.output_dir()}`.")
         log.info("")
@@ -401,36 +504,39 @@ class Project():
             log.warning("Remote GitHub repository is not yet configured.")
             log.info("")
             log.info(
-                "And if you haven't already, create a remote GitHub repository for this project at:")
+                "And if you haven't already, create a remote GitHub repository for this project at:"
+            )
             log.info("    https://github.com/new")
-            log.info("(Do NOT check any \"initialize\" options.)")
+            log.info('(Do NOT check any "initialize" options.)')
             log.info(
-                "On the next page, copy the URL in the \"Quick Setup\" section (use HTTPS unless you have SSH setup already).")
+                'On the next page, copy the URL in the "Quick Setup" section (use HTTPS unless you have SSH setup already).'
+            )
             log.info("")
             repourl = input("Paste url here: ").strip()
             repo.create_remote("origin", url=repourl)
             origin = repo.remotes.origin
-            log.info("\nFor information about authentication options for github, see: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-authentication-to-github\n")
+            log.info(
+                "\nFor information about authentication options for github, see: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-authentication-to-github\n"
+            )
         log.info(f"Committing your latest build to the `gh-pages` branch.")
         log.info("")
         ghp_import.ghp_import(
             target.output_dir(),
             mesg=f"Latest build of target {target.name()}.",
-            nojekyll=True
+            nojekyll=True,
         )
-        log.info(
-            f"Attempting to connect to remote repository at `{origin.url}`...")
+        log.info(f"Attempting to connect to remote repository at `{origin.url}`...")
         # log.info("(Your SSH password may be required.)")
         log.info("")
         try:
-            if not(origin.url.endswith('.git')):
-                origin.url = origin.url + '.git'
-            repo_user = re.split('/|:|.git$', origin.url)[-3]
-            repo_name = re.split('/|:|.git$', origin.url)[-2]
+            if not (origin.url.endswith(".git")):
+                origin.url = origin.url + ".git"
+            repo_user = re.split("/|:|.git$", origin.url)[-3]
+            repo_name = re.split("/|:|.git$", origin.url)[-2]
             repo_url = f"https://github.com/{repo_user}/{repo_name}/"
             print(repo_url)
             # Set pages_url depending on whether project is base pages for the user or a separate repo
-            if 'github.io' in repo_name:
+            if "github.io" in repo_name:
                 pages_url = f"https://{repo_name}/"
             else:
                 pages_url = f"https://{repo_user}.github.io/{repo_name}/"
@@ -439,23 +545,25 @@ class Project():
             log.error("Deploy unsuccessful")
             return
         try:
-            origin.push(
-                refspec=f"{repo.active_branch.name}:{repo.active_branch.name}")
+            origin.push(refspec=f"{repo.active_branch.name}:{repo.active_branch.name}")
             origin.push(refspec=f"gh-pages:gh-pages")
         except git.exc.GitCommandError:
             log.warning(
-                f"There was an issue connecting to GitHub repository located at {repo_url}")
+                f"There was an issue connecting to GitHub repository located at {repo_url}"
+            )
             log.info("")
             log.info(
-                "If you haven't already, configure SSH with GitHub by following instructions at:")
+                "If you haven't already, configure SSH with GitHub by following instructions at:"
+            )
             log.info(
-                "    https://docs.github.com/en/authentication/connecting-to-github-with-ssh")
+                "    https://docs.github.com/en/authentication/connecting-to-github-with-ssh"
+            )
             log.info("Then try to deploy again.")
             log.info("")
+            log.info(f"If `{origin.url}` doesn't match your GitHub repository,")
             log.info(
-                f"If `{origin.url}` doesn't match your GitHub repository,")
-            log.info(
-                "use `git remote remove origin` on the command line then try to deploy again.")
+                "use `git remote remove origin` on the command line then try to deploy again."
+            )
             log.info("")
             log.error("Deploy was unsuccessful.")
             return
@@ -488,20 +596,18 @@ class Project():
             # Would we ever have a publication with xi:include?  Just in case...
             publication_xml.xinclude()
         except Exception as e:
-            log.critical(f'Unable to read publication file.  Quitting. {e}')
-            log.debug('', exc_info=True)
+            log.critical(f"Unable to read publication file.  Quitting. {e}")
+            log.debug("", exc_info=True)
             return False
-        if (publication_xml.getroot().tag != 'publication'):
+        if publication_xml.getroot().tag != "publication":
             log.error(
-                f'The publication file {target.publication()} must have "<publication>" as its root element.')
+                f'The publication file {target.publication()} must have "<publication>" as its root element.'
+            )
             return False
         return True
 
     def executables(self):
-        return {
-            ele.tag: ele.text
-            for ele in self.xml_element().xpath("executables/*")
-        }
+        return {ele.tag: ele.text for ele in self.xml_element().xpath("executables/*")}
 
     def init_ptxcore(self):
         core.set_executables(self.executables())

--- a/pretext/project.py
+++ b/pretext/project.py
@@ -1,7 +1,8 @@
 import re
 from lxml import etree as ET
 from lxml.etree import Element
-import os, shutil
+import os
+import shutil
 import logging
 import tempfile
 from . import utils, generate, core
@@ -13,8 +14,9 @@ import webbrowser
 
 log = logging.getLogger('ptxlogger')
 
+
 class Target():
-    def __init__(self,xml_element,project_path):
+    def __init__(self, xml_element, project_path):
         # construction is done!
         self.__xml_element = xml_element
         self.__project_path = Path(project_path).resolve()
@@ -38,7 +40,7 @@ class Target():
         if pdf_method is not None:
             return pdf_method.strip()
         else:
-            return "xelatex" # default
+            return "xelatex"  # default
 
     def format(self) -> str:
         return self.xml_element().find("format").text.strip()
@@ -92,7 +94,7 @@ class Target():
             return None
         else:
             return self.xml_element().find("output-filename").text.strip()
-    
+
     def port(self) -> int:
         view_ele = self.xml_element().find("view")
         if view_ele is not None and view_ele.get("port") is not None:
@@ -105,7 +107,7 @@ class Target():
             sp_ele.get("key").strip(): sp_ele.get("value").strip()
             for sp_ele in self.xml_element().xpath("stringparam")
         }
-    
+
     def xsl_path(self) -> Optional[Path]:
         if self.xml_element().find("xsl") is not None:
             return (Path(self.__project_path)/self.xml_element().find("xsl").text.strip()).resolve()
@@ -116,13 +118,12 @@ class Target():
         ele = self.xml_element().find("xmlid-root")
         if ele is None:
             return None
-        else:   
+        else:
             return ele.text.strip()
 
 
-
 class Project():
-    def __init__(self,project_path=None):
+    def __init__(self, project_path=None):
         project_path = project_path or utils.project_path()
         xml_element = ET.parse(project_path/"project.ptx").getroot()
         self.__xml_element = xml_element
@@ -135,7 +136,8 @@ class Project():
 
     def targets(self):
         return [
-            Target(xml_element=target_element,project_path=self.__project_path)
+            Target(xml_element=target_element,
+                   project_path=self.__project_path)
             for target_element in self.xml_element().xpath("targets/target")
         ]
 
@@ -151,17 +153,18 @@ class Project():
         for target in self.targets():
             print(target.name())
 
-    def target(self,name=None) -> Target:
+    def target(self, name=None) -> Target:
         if name is None:
-            target_element=self.xml_element().find("targets/target")
+            target_element = self.xml_element().find("targets/target")
         else:
-            target_element=self.xml_element().find(f'targets/target[@name="{name}"]')
+            target_element = self.xml_element().find(
+                f'targets/target[@name="{name}"]')
         if target_element is not None:
-            return Target(xml_element=target_element,project_path=self.__project_path)
+            return Target(xml_element=target_element, project_path=self.__project_path)
         else:
             return None
 
-    def view(self,target_name:str,access:str,port:int,watch:bool=False, no_launch:bool=False):
+    def view(self, target_name: str, access: str, port: int, watch: bool = False, no_launch: bool = False):
         target = self.target(target_name)
         directory = target.output_dir()
         if watch:
@@ -170,16 +173,20 @@ class Project():
             watch_directory = None
         if not target.output_dir().exists():
             log.error(f"The directory `{target.output_dir()}` does not exist.")
-            log.error(f"Run `pretext view {target.name()} -b` to build your project before viewing.")
+            log.error(
+                f"Run `pretext view {target.name()} -b` to build your project before viewing.")
             return
-        watch_callback=lambda:self.build(target_name)
+
+        def watch_callback(): return self.build(target_name)
         if utils.cocalc_project_id() is not None:
             if target.format() in ['html', 'pdf']:
-                utils.run_server(directory,access,port,watch_directory,watch_callback,no_launch)
+                utils.run_server(directory, access, port,
+                                 watch_directory, watch_callback, no_launch)
             else:
                 log.info(f"Output can be viewed by navigating to {directory}")
         elif target.format() == 'html':
-            utils.run_server(directory,access,port,watch_directory,watch_callback,no_launch)
+            utils.run_server(directory, access, port,
+                             watch_directory, watch_callback, no_launch)
         else:
             outputfiles = list(Path(directory).glob("*.*"))
             log.info(f"Output can be viewed by navigating to {directory}")
@@ -189,11 +196,12 @@ class Project():
                 try:
                     outputfile = str(outputfiles[0])
                     webbrowser.open(outputfile)
-                    log.info(f"Attempting to open output using default viewer for {target.format()} files.  If this doesn't work, you can open {outputfile} manually.")
+                    log.info(
+                        f"Attempting to open output using default viewer for {target.format()} files.  If this doesn't work, you can open {outputfile} manually.")
                 except:
                     return
 
-    def build(self,target_name,clean=False):
+    def build(self, target_name, clean=False):
         target = self.target(target_name)
         # Check for xml syntax errors and quit if xml invalid:
         if not self.xml_source_is_valid(target_name):
@@ -205,21 +213,26 @@ class Project():
         if clean:
             # refuse to clean if output is not a subdirectory of the working directory or contains source/publication
             if Path(self.__project_path) not in target.output_dir().parents:
-                log.warning("Refusing to clean output directory that isn't a proper subdirectory of the project.")
+                log.warning(
+                    "Refusing to clean output directory that isn't a proper subdirectory of the project.")
             elif target.output_dir() in (target.source_dir()/"foo").parents or \
-                target.output_dir() in (target.publication_dir()/"foo").parents:
-                log.warning("Refusing to clean output directory that contains source or publication files.")
+                    target.output_dir() in (target.publication_dir()/"foo").parents:
+                log.warning(
+                    "Refusing to clean output directory that contains source or publication files.")
             # handle request to clean directory that does not exist
             elif not target.output_dir().exists():
-                log.warning(f"Directory {target.output_dir()} already does not exist, nothing to clean.")
+                log.warning(
+                    f"Directory {target.output_dir()} already does not exist, nothing to clean.")
             else:
-                log.warning(f"Destroying directory {target.output_dir()} to clean previously built files.")
+                log.warning(
+                    f"Destroying directory {target.output_dir()} to clean previously built files.")
                 shutil.rmtree(target.output_dir())
-        #if custom xsl, copy it into a temporary directory (different from the building temporary directory)
+        # if custom xsl, copy it into a temporary directory (different from the building temporary directory)
         custom_xsl = None
         if target.xsl_path() is not None:
             temp_xsl_path = Path(tempfile.mkdtemp())
-            log.info(f'Building with custom xsl {target.xsl_path()} specified in project.ptx')
+            log.info(
+                f'Building with custom xsl {target.xsl_path()} specified in project.ptx')
             utils.copy_custom_xsl(target.xsl_path(), temp_xsl_path)
             custom_xsl = temp_xsl_path/target.xsl_path().name
         # warn if "publisher" is one of the string-param keys:
@@ -227,42 +240,57 @@ class Project():
             log.warning('You specified a publication file via a stringparam.  This is ignored in favor of the publication file given by the <publication> element in the project manifest.')
         log.info(f"Preparing to build into {target.output_dir()}.")
         try:
-            if (target.format()=='html' or target.format()=='html-zip'):
-                zipped = (target.format()=='html-zip')
-                builder.html(target.source(),target.publication(),target.output_dir(),target.stringparams(),custom_xsl,target.xmlid_root(),zipped)
-            elif target.format()=='latex':
-                builder.latex(target.source(),target.publication(),target.output_dir(),target.stringparams(),custom_xsl)
+            if (target.format() == 'html' or target.format() == 'html-zip'):
+                zipped = (target.format() == 'html-zip')
+                builder.html(target.source(), target.publication(), target.output_dir(
+                ), target.stringparams(), custom_xsl, target.xmlid_root(), zipped)
+            elif target.format() == 'latex':
+                builder.latex(target.source(), target.publication(
+                ), target.output_dir(), target.stringparams(), custom_xsl)
                 # core script doesn't put a copy of images in output for latex builds, so we do it instead here
-                shutil.copytree(target.external_dir(),target.output_dir()/"external",dirs_exist_ok=True)
-                shutil.copytree(target.generated_dir(),target.output_dir()/"generated",dirs_exist_ok=True)
-            elif target.format()=='pdf':
-                builder.pdf(target.source(),target.publication(),target.output_dir(),target.stringparams(),custom_xsl,target.pdf_method())
-            elif target.format()=='custom':
+                shutil.copytree(target.external_dir(
+                ), target.output_dir()/"external", dirs_exist_ok=True)
+                shutil.copytree(target.generated_dir(
+                ), target.output_dir()/"generated", dirs_exist_ok=True)
+            elif target.format() == 'pdf':
+                builder.pdf(target.source(), target.publication(), target.output_dir(
+                ), target.stringparams(), custom_xsl, target.pdf_method())
+            elif target.format() == 'custom':
                 if custom_xsl is None:
-                    raise Exception("Must specify custom XSL for custom build.")
-                builder.custom(target.source(),target.publication(),target.output_dir(),target.stringparams(),custom_xsl,target.output_filename())
-            elif target.format()=='epub':
-                builder.epub(target.source(),target.publication(),target.output_dir(),target.stringparams())
-            elif target.format()=='kindle':
-                builder.kindle(target.source(),target.publication(),target.output_dir(),target.stringparams())
-            elif target.format()=='braille' or target.format()=='braille-emboss':
-                builder.braille(target.source(),target.publication(),target.output_dir(),target.stringparams(),page_format="emboss")
-            elif target.format()=='braille-electronic':
-                builder.braille(target.source(),target.publication(),target.output_dir(),target.stringparams(),page_format="electronic")
+                    raise Exception(
+                        "Must specify custom XSL for custom build.")
+                builder.custom(target.source(), target.publication(), target.output_dir(
+                ), target.stringparams(), custom_xsl, target.output_filename())
+            elif target.format() == 'epub':
+                builder.epub(target.source(), target.publication(),
+                             target.output_dir(), target.stringparams())
+            elif target.format() == 'kindle':
+                builder.kindle(target.source(), target.publication(
+                ), target.output_dir(), target.stringparams())
+            elif target.format() == 'braille' or target.format() == 'braille-emboss':
+                builder.braille(target.source(), target.publication(
+                ), target.output_dir(), target.stringparams(), page_format="emboss")
+            elif target.format() == 'braille-electronic':
+                builder.braille(target.source(), target.publication(
+                ), target.output_dir(), target.stringparams(), page_format="electronic")
             else:
-                log.critical(f'The build format {target.format()} is not supported.')
+                log.critical(
+                    f'The build format {target.format()} is not supported.')
         except Exception as e:
             log.critical(
                 f"A fatal error has occurred:\n {e} \nFor more info, run pretext with `-v debug`")
             log.debug(f"Exception info:\n##################\n", exc_info=True)
             log.info('##################')
-            sys.exit(f"Failed to build pretext target {target.format()}.  Exiting...")
+            sys.exit(
+                f"Failed to build pretext target {target.format()}.  Exiting...")
         # build was successful
-        log.info(f"\nSuccess! Run `pretext view {target.name()}` to see the results.\n")
+        log.info(
+            f"\nSuccess! Run `pretext view {target.name()}` to see the results.\n")
         if custom_xsl is not None:
-            shutil.rmtree(custom_xsl.parent, ignore_errors=True) #errors may occur in Windows so we do the best we can
-    
-    def generate(self,target_name,asset_list=None,all_formats=False,xmlid=None):
+            # errors may occur in Windows so we do the best we can
+            shutil.rmtree(custom_xsl.parent, ignore_errors=True)
+
+    def generate(self, target_name, asset_list=None, all_formats=False, xmlid=None):
         if asset_list is None:
             asset_list = []
             gen_all = True
@@ -273,7 +301,7 @@ class Project():
         if target is None:
             log.error(f"Target `{target_name}` not found.")
             return
-        #build targets:
+        # build targets:
         if gen_all or "webwork" in asset_list:
             webwork_output = target.generated_dir()/'webwork'
             generate.webwork(
@@ -281,44 +309,47 @@ class Project():
             )
         if gen_all or "latex-image" in asset_list:
             generate.latex_image(
-                target.source(), target.publication(), target.generated_dir(), target.stringparams(), 
+                target.source(), target.publication(), target.generated_dir(), target.stringparams(),
                 target.format(), xmlid, target.pdf_method(), all_formats
             )
         if gen_all or "asymptote" in asset_list:
             generate.asymptote(
-                target.source(), target.publication(), target.generated_dir(), target.stringparams(), 
+                target.source(), target.publication(), target.generated_dir(), target.stringparams(),
                 target.format(), xmlid, all_formats
             )
         if gen_all or "sageplot" in asset_list:
             generate.sageplot(
-                target.source(), target.publication(), target.generated_dir(), target.stringparams(), 
+                target.source(), target.publication(), target.generated_dir(), target.stringparams(),
                 target.format(), xmlid, all_formats
             )
         if gen_all or "interactive" in asset_list:
             generate.interactive(
-                target.source(), target.publication(), target.generated_dir(), target.stringparams(), 
+                target.source(), target.publication(), target.generated_dir(), target.stringparams(),
                 xmlid,
             )
         if gen_all or "youtube" in asset_list:
             generate.youtube(
-                target.source(), target.publication(), target.generated_dir(), target.stringparams(), 
+                target.source(), target.publication(), target.generated_dir(), target.stringparams(),
                 xmlid,
             )
         if gen_all or "codelens" in asset_list:
             generate.codelens(
-                target.source(), target.publication(), target.generated_dir(), target.stringparams(), 
+                target.source(), target.publication(), target.generated_dir(), target.stringparams(),
                 xmlid,
             )
 
-    def deploy(self,target_name,update_source):
+    def deploy(self, target_name, update_source):
         try:
-            import git, ghp_import
+            import git
+            import ghp_import
         except ImportError:
-            log.error("Git must be installed to use this feature, but couldn't be found.")
-            log.error("Visit https://github.com/git-guides/install-git for assistance.")
+            log.error(
+                "Git must be installed to use this feature, but couldn't be found.")
+            log.error(
+                "Visit https://github.com/git-guides/install-git for assistance.")
             return
         target = self.target(target_name)
-        if target.format() != "html": #redundent for CLI
+        if target.format() != "html":  # redundant for CLI
             log.error("Only HTML format targets are supported.")
             return
         try:
@@ -341,9 +372,10 @@ class Project():
             repo.active_branch.rename("main")
             log.info("Successfully initialized new Git repository!")
             log.info("")
-        log.info(f"Preparing to deploy from active `{repo.active_branch.name}` git branch.")
+        log.info(
+            f"Preparing to deploy from active `{repo.active_branch.name}` git branch.")
         log.info("")
-        if repo.bare or repo.is_dirty() or len(repo.untracked_files)>0:
+        if repo.bare or repo.is_dirty() or len(repo.untracked_files) > 0:
             log.info("Changes to project source since last commit detected.")
             if update_source:
                 log.info("Add/committing these changes to local Git repository.")
@@ -352,11 +384,14 @@ class Project():
                 repo.git.commit(message="Update to PreTeXt project source.")
             else:
                 log.error("Either add and commit these changes with Git, or run")
-                log.error("`pretext deploy -u` to have these changes updated automatically.")
+                log.error(
+                    "`pretext deploy -u` to have these changes updated automatically.")
                 return
         if not target.output_dir().exists():
-            log.error(f"No build for `{target.name()}` was found in the directory `{target.output_dir()}`.")
-            log.error(f"Try running `pretext view {target.name()} -b` to build and preview your project first.")
+            log.error(
+                f"No build for `{target.name()}` was found in the directory `{target.output_dir()}`.")
+            log.error(
+                f"Try running `pretext view {target.name()} -b` to build and preview your project first.")
             return
         log.info(f"Using latest build located in `{target.output_dir()}`.")
         log.info("")
@@ -365,30 +400,33 @@ class Project():
         except AttributeError:
             log.warning("Remote GitHub repository is not yet configured.")
             log.info("")
-            log.info("And if you haven't already, create a remote GitHub repository for this project at:")
+            log.info(
+                "And if you haven't already, create a remote GitHub repository for this project at:")
             log.info("    https://github.com/new")
             log.info("(Do NOT check any \"initialize\" options.)")
-            log.info("On the next page, copy the URL in the \"Quick Setup\" section (use HTTPS unless you have SSH setup already).")
+            log.info(
+                "On the next page, copy the URL in the \"Quick Setup\" section (use HTTPS unless you have SSH setup already).")
             log.info("")
             repourl = input("Paste url here: ").strip()
             repo.create_remote("origin", url=repourl)
             origin = repo.remotes.origin
             log.info("\nFor information about authentication options for github, see: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-authentication-to-github\n")
-        log.info(f"Commiting your latest build to the `gh-pages` branch.")
+        log.info(f"Committing your latest build to the `gh-pages` branch.")
         log.info("")
         ghp_import.ghp_import(
-            target.output_dir(), 
+            target.output_dir(),
             mesg=f"Latest build of target {target.name()}.",
             nojekyll=True
         )
-        log.info(f"Attempting to connect to remote repository at `{origin.url}`...")
+        log.info(
+            f"Attempting to connect to remote repository at `{origin.url}`...")
         # log.info("(Your SSH password may be required.)")
         log.info("")
         try:
             if not(origin.url.endswith('.git')):
                 origin.url = origin.url + '.git'
-            repo_user = re.split('/|:|.git$',origin.url)[-3]
-            repo_name = re.split('/|:|.git$',origin.url)[-2]
+            repo_user = re.split('/|:|.git$', origin.url)[-3]
+            repo_name = re.split('/|:|.git$', origin.url)[-2]
             repo_url = f"https://github.com/{repo_user}/{repo_name}/"
             print(repo_url)
             # Set pages_url depending on whether project is base pages for the user or a separate repo
@@ -401,17 +439,23 @@ class Project():
             log.error("Deploy unsuccessful")
             return
         try:
-            origin.push(refspec=f"{repo.active_branch.name}:{repo.active_branch.name}")
+            origin.push(
+                refspec=f"{repo.active_branch.name}:{repo.active_branch.name}")
             origin.push(refspec=f"gh-pages:gh-pages")
         except git.exc.GitCommandError:
-            log.warning(f"There was an issue connecting to GitHub repository located at {repo_url}")
+            log.warning(
+                f"There was an issue connecting to GitHub repository located at {repo_url}")
             log.info("")
-            log.info("If you haven't already, configure SSH with GitHub by following instructions at:")
-            log.info("    https://docs.github.com/en/authentication/connecting-to-github-with-ssh")
+            log.info(
+                "If you haven't already, configure SSH with GitHub by following instructions at:")
+            log.info(
+                "    https://docs.github.com/en/authentication/connecting-to-github-with-ssh")
             log.info("Then try to deploy again.")
             log.info("")
-            log.info(f"If `{origin.url}` doesn't match your GitHub repository,")
-            log.info("use `git remote remove origin` on the command line then try to deploy again.")
+            log.info(
+                f"If `{origin.url}` doesn't match your GitHub repository,")
+            log.info(
+                "use `git remote remove origin` on the command line then try to deploy again.")
             log.info("")
             log.error("Deploy was unsuccessful.")
             return
@@ -429,15 +473,15 @@ class Project():
         log.info("Your built project will soon be available to the public at:")
         log.info(f"    {pages_url}")
 
-    def xml_source_is_valid(self,target_name):
+    def xml_source_is_valid(self, target_name):
         target = self.target(target_name)
         return utils.xml_syntax_is_valid(target.source())
 
-    def xml_schema_validate(self,target_name):
+    def xml_schema_validate(self, target_name):
         target = self.target(target_name)
         return utils.xml_source_validates_against_schema(target.source())
 
-    def xml_publication_is_valid(self,target_name):
+    def xml_publication_is_valid(self, target_name):
         target = self.target(target_name)
         try:
             publication_xml = ET.parse(target.publication())
@@ -448,7 +492,8 @@ class Project():
             log.debug('', exc_info=True)
             return False
         if (publication_xml.getroot().tag != 'publication'):
-            log.error(f'The publication file {target.publication()} must have "<publication>" as its root element.')
+            log.error(
+                f'The publication file {target.publication()} must have "<publication>" as its root element.')
             return False
         return True
 

--- a/pretext/templates/__init__.py
+++ b/pretext/templates/__init__.py
@@ -10,4 +10,5 @@ def resource_path(filename: str) -> Path:
         # do things
     """
     from . import resources
+
     return importlib.resources.path(resources, filename)

--- a/pretext/templates/__init__.py
+++ b/pretext/templates/__init__.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 import importlib.resources
 
-def resource_path(filename:str) -> Path:
+
+def resource_path(filename: str) -> Path:
     """
     Returns resource manager
     Usage:
@@ -9,4 +10,4 @@ def resource_path(filename:str) -> Path:
         # do things
     """
     from . import resources
-    return importlib.resources.path(resources,filename)
+    return importlib.resources.path(resources, filename)

--- a/pretext/utils.py
+++ b/pretext/utils.py
@@ -22,10 +22,11 @@ from lxml import etree as ET
 from . import core
 
 # Get access to logger
-log = logging.getLogger('ptxlogger')
+log = logging.getLogger("ptxlogger")
+
 
 @contextmanager
-def working_directory(path:Path):
+def working_directory(path: Path):
     """
     Temporarily change the current working directory.
 
@@ -34,7 +35,7 @@ def working_directory(path:Path):
         do_things()   # working in the given path
     do_other_things() # back to original path
     """
-    current_directory=Path()
+    current_directory = Path()
     os.chdir(path)
     log.debug(f"Now working in directory {path}")
     try:
@@ -43,11 +44,12 @@ def working_directory(path:Path):
         os.chdir(current_directory)
         log.debug(f"Successfully changed directory back to {current_directory}")
 
+
 # Grabs project directory based on presence of `project.ptx`
-def project_path(dirpath:Optional[Path]=None) -> Path:
-    if dirpath==None:
-        dirpath = Path().resolve() # current directory
-    if (dirpath/"project.ptx").is_file():
+def project_path(dirpath: Optional[Path] = None) -> Path:
+    if dirpath == None:
+        dirpath = Path().resolve()  # current directory
+    if (dirpath / "project.ptx").is_file():
         # we're at the project root
         return dirpath
     if dirpath.parent == dirpath:
@@ -57,76 +59,88 @@ def project_path(dirpath:Optional[Path]=None) -> Path:
         # check parent instead
         return project_path(dirpath=dirpath.parent)
 
-def project_xml(dirpath:Optional[Path]=None) -> Path:
+
+def project_xml(dirpath: Optional[Path] = None) -> Path:
     if dirpath is None:
-        dirpath = Path() # current directory
+        dirpath = Path()  # current directory
     if project_path(dirpath) is None:
-        with templates.resource_path('project.ptx') as project_manifest:
+        with templates.resource_path("project.ptx") as project_manifest:
             return ET.parse(project_manifest)
     else:
-        project_manifest = project_path(dirpath) / 'project.ptx'
+        project_manifest = project_path(dirpath) / "project.ptx"
         return ET.parse(project_manifest)
 
-def requirements_version(dirpath:Optional[Path]=None) -> str:
-    if dirpath==None:
-        dirpath = Path() # current directory
+
+def requirements_version(dirpath: Optional[Path] = None) -> str:
+    if dirpath == None:
+        dirpath = Path()  # current directory
     try:
-        with open(project_path(dirpath) / 'requirements.txt','r') as f:
+        with open(project_path(dirpath) / "requirements.txt", "r") as f:
             for line in f.readlines():
-                if 'pretext' or 'pretextbook' in line:
+                if "pretext" or "pretextbook" in line:
                     return line.split("==")[1].strip()
     except Exception as e:
         log.debug("Could not read `requirements.txt`:")
         log.debug(e)
         return None
 
-def project_xml_string(dirpath:Optional[Path]=None) -> str:
-    if dirpath==None:
-        dirpath = Path() # current directory
-    return ET.tostring(project_xml(dirpath), encoding='unicode')
 
-def target_xml(alias:Optional[str]=None,dirpath:Optional[Path]=None) -> ET.Element:
-    if dirpath==None:
-        dirpath = Path() # current directory
+def project_xml_string(dirpath: Optional[Path] = None) -> str:
+    if dirpath == None:
+        dirpath = Path()  # current directory
+    return ET.tostring(project_xml(dirpath), encoding="unicode")
+
+
+def target_xml(
+    alias: Optional[str] = None, dirpath: Optional[Path] = None
+) -> ET.Element:
+    if dirpath == None:
+        dirpath = Path()  # current directory
     if alias is None:
-        return project_xml().find("targets/target") # first target
+        return project_xml().find("targets/target")  # first target
     xpath = f'targets/target[@name="{alias}"]'
     matches = project_xml().xpath(xpath)
     if len(matches) == 0:
-        log.info(f"No targets with alias {alias} found in project manifest file project.ptx.")
+        log.info(
+            f"No targets with alias {alias} found in project manifest file project.ptx."
+        )
         return None
     return project_xml().xpath(xpath)[0]
 
-#check xml syntax
-def xml_syntax_is_valid(xmlfile:Path) -> bool:
+
+# check xml syntax
+def xml_syntax_is_valid(xmlfile: Path) -> bool:
     # parse xml
     try:
         source_xml = ET.parse(xmlfile)
         # we need to call xinclude once for each level of nesting (just to check for errors).  25 levels should be more than sufficient
         for i in range(25):
             source_xml.xinclude()
-        log.debug('XML syntax appears well formed.')
-        if (source_xml.getroot().tag != 'pretext'):
-            log.error(f'The file {xmlfile} does not have "<pretext>" as its root element.  Did you use a subfile as your source?  Check the project manifest (project.ptx).')
+        log.debug("XML syntax appears well formed.")
+        if source_xml.getroot().tag != "pretext":
+            log.error(
+                f'The file {xmlfile} does not have "<pretext>" as its root element.  Did you use a subfile as your source?  Check the project manifest (project.ptx).'
+            )
             return False
     # check for file IO error
     except IOError:
-        log.error(f'The file {xmlfile} does not exist')
+        log.error(f"The file {xmlfile} does not exist")
         return False
     # check for XML syntax errors
     except ET.XMLSyntaxError as err:
-        log.error('XML Syntax Error caused build to fail:')
+        log.error("XML Syntax Error caused build to fail:")
         log.error(str(err.error_log))
         return False
     except ET.XIncludeError as err:
-        log.error('XInclude Error caused build to fail:')
+        log.error("XInclude Error caused build to fail:")
         log.error(str(err.error_log))
         return False
     return True
 
-def xml_source_validates_against_schema(xmlfile:Path) -> bool:
-    #get path to RelaxNG schema file:
-    schemarngfile = core.resources.path('schema','pretext.rng')
+
+def xml_source_validates_against_schema(xmlfile: Path) -> bool:
+    # get path to RelaxNG schema file:
+    schemarngfile = core.resources.path("schema", "pretext.rng")
 
     # Open schemafile for validation:
     relaxng = ET.RelaxNG(file=schemarngfile)
@@ -142,26 +156,31 @@ def xml_source_validates_against_schema(xmlfile:Path) -> bool:
     # validate against schema
     try:
         relaxng.assertValid(source_xml)
-        log.info('PreTeXt source passed schema validation.')
+        log.info("PreTeXt source passed schema validation.")
     except ET.DocumentInvalid as err:
-        log.debug('PreTeXt document did not pass schema validation; unexpected output may result. See .error_schema.log for hints.  Continuing with build.')
-        with open('.error_schema.log', 'w') as error_log_file:
+        log.debug(
+            "PreTeXt document did not pass schema validation; unexpected output may result. See .error_schema.log for hints.  Continuing with build."
+        )
+        with open(".error_schema.log", "w") as error_log_file:
             error_log_file.write(str(err.error_log))
         return False
     return True
 
+
 def cocalc_project_id() -> Optional[str]:
     try:
-        return json.loads(open('/home/user/.smc/info.json').read())['project_id']
+        return json.loads(open("/home/user/.smc/info.json").read())["project_id"]
     except:
         return None
 
+
 # watchdog handler for watching changes to source
 class HTMLRebuildHandler(watchdog.events.FileSystemEventHandler):
-    def __init__(self,callback):
-        self.last_trigger_at = time.time()-5
+    def __init__(self, callback):
+        self.last_trigger_at = time.time() - 5
         self.callback = callback
-    def on_any_event(self,event):
+
+    def on_any_event(self, event):
         self.last_trigger_at = time.time()
         # only run callback once triggers halt for a second
         def timeout_callback(handler):
@@ -170,50 +189,70 @@ class HTMLRebuildHandler(watchdog.events.FileSystemEventHandler):
                 handler.last_trigger_at = time.time()
                 log.info("\nChanges to source detected.\n")
                 handler.callback()
-        threading.Thread(target=timeout_callback,args=(self,)).start()
+
+        threading.Thread(target=timeout_callback, args=(self,)).start()
+
 
 # boilerplate to prevent overzealous caching by preview server, and
 # avoid port issues
 def binding_for_access(access="private"):
-    if access=="public" or cocalc_project_id() is not None:
+    if access == "public" or cocalc_project_id() is not None:
         return "0.0.0.0"
     else:
         return "localhost"
-def url_for_access(access="private",port=8000):
+
+
+def url_for_access(access="private", port=8000):
     if cocalc_project_id() is not None:
         return f"https://cocalc.com/{cocalc_project_id()}/server/{port}/"
-    elif access=='public':
+    elif access == "public":
         return f"http://{socket.gethostbyname(socket.gethostname())}:{port}"
     else:
         return f"http://localhost:{port}"
-def serve_forever(directory:Path,access="private",port=8000,no_launch:bool=False):
+
+
+def serve_forever(
+    directory: Path, access="private", port=8000, no_launch: bool = False
+):
     log.info(f"Now preparing local server to preview directory `{directory}`.")
-    log.info("  (Reminder: use `pretext deploy` to deploy your built project to a public")
-    log.info("  GitHub Pages site that can be shared with readers who cannot access your")
+    log.info(
+        "  (Reminder: use `pretext deploy` to deploy your built project to a public"
+    )
+    log.info(
+        "  GitHub Pages site that can be shared with readers who cannot access your"
+    )
     log.info("  personal computer.)")
     log.info("")
     binding = binding_for_access(access)
+
     class RequestHandler(SimpleHTTPRequestHandler):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, directory=directory.as_posix(), **kwargs)
+
         """HTTP request handler with no caching"""
+
         def end_headers(self):
             self.send_my_headers()
             SimpleHTTPRequestHandler.end_headers(self)
+
         def send_my_headers(self):
             self.send_header("Cache-Control", "no-cache, no-store, must-revalidate")
             self.send_header("Pragma", "no-cache")
             self.send_header("Expires", "0")
+
     class TCPServer(socketserver.TCPServer):
         allow_reuse_address = True
+
     looking_for_port = True
     while looking_for_port:
         try:
             with TCPServer((binding, port), RequestHandler) as httpd:
                 looking_for_port = False
-                url = url_for_access(access,port)
-                log.info(f"Success! The most recent build of your project can be viewed in a web browser at the following url:")
-                log.info("    "+url)
+                url = url_for_access(access, port)
+                log.info(
+                    f"Success! The most recent build of your project can be viewed in a web browser at the following url:"
+                )
+                log.info("    " + url)
                 if not no_launch:
                     log.info(f"This page should open in a new tab automatically.")
                     webbrowser.open(url)
@@ -221,12 +260,22 @@ def serve_forever(directory:Path,access="private",port=8000,no_launch:bool=False
                 httpd.serve_forever()
         except OSError:
             log.warning(f"Port {port} could not be used.")
-            port = random.randint(49152,65535)
+            port = random.randint(49152, 65535)
             log.warning(f"Trying port {port} instead.\n")
 
-def run_server(directory:Path,access:str,port:int,watch_directory:Optional[Path]=None,watch_callback=lambda:None, no_launch:bool=False):
+
+def run_server(
+    directory: Path,
+    access: str,
+    port: int,
+    watch_directory: Optional[Path] = None,
+    watch_callback=lambda: None,
+    no_launch: bool = False,
+):
     binding = binding_for_access(access)
-    threading.Thread(target=lambda: serve_forever(directory,access,port,no_launch),daemon=True).start()
+    threading.Thread(
+        target=lambda: serve_forever(directory, access, port, no_launch), daemon=True
+    ).start()
     if watch_directory is not None:
         log.info(f"\nWatching for changes in `{watch_directory}` ...\n")
         event_handler = HTMLRebuildHandler(watch_callback)
@@ -238,16 +287,22 @@ def run_server(directory:Path,access:str,port:int,watch_directory:Optional[Path]
             time.sleep(1)
     except KeyboardInterrupt:
         log.info("\nClosing server...")
-        if watch_directory is not None: observer.stop()
-    if watch_directory is not None: observer.join()
+        if watch_directory is not None:
+            observer.stop()
+    if watch_directory is not None:
+        observer.join()
+
 
 # Info on namespaces: http://lxml.de/tutorial.html#namespaces
 NSMAP = {
     "xi": "http://www.w3.org/2001/XInclude",
     "xml": "http://www.w3.org/XML/1998/namespace",
 }
-def nstag(prefix:str,suffix:str) -> str:
+
+
+def nstag(prefix: str, suffix: str) -> str:
     return "{" + NSMAP[prefix] + "}" + suffix
+
 
 def copy_custom_xsl(xsl_path: Path, output_dir: Path):
     """
@@ -259,15 +314,17 @@ def copy_custom_xsl(xsl_path: Path, output_dir: Path):
     log.debug(f"Copying all files in {xsl_dir} to {output_dir}")
     shutil.copytree(xsl_dir, output_dir, dirs_exist_ok=True)
     log.debug(f"Copying core XSL to {output_dir}/core")
-    shutil.copytree(core.resources.path('xsl'),output_dir/"core")
+    shutil.copytree(core.resources.path("xsl"), output_dir / "core")
 
-def check_executable(exec_name:str):
+
+def check_executable(exec_name: str):
     try:
         exec_cmd = core.get_executable_cmd(exec_name)[0]
         log.debug(f"PTX-CLI: Executable command {exec_name} found at {exec_cmd}")
         return exec_cmd
     except OSError as e:
         log.debug(e)
+
 
 def check_asset_execs(element, outformats=None):
     # outformats is assumed to be a list of formats.
@@ -278,103 +335,131 @@ def check_asset_execs(element, outformats=None):
     # Create list of executables needed based on output format
     required_execs = []
     if element == "latex-image":
-        required_execs = ['xelatex']
-        if 'svg' in outformats or 'all' in outformats:
-            required_execs.append('pdfsvg')
-        if 'png' in outformats or 'all' in outformats:
-            required_execs.append('pdfpng')
-        if 'eps' in outformats or 'all' in outformats:
-            required_execs.append('pdfeps')
+        required_execs = ["xelatex"]
+        if "svg" in outformats or "all" in outformats:
+            required_execs.append("pdfsvg")
+        if "png" in outformats or "all" in outformats:
+            required_execs.append("pdfpng")
+        if "eps" in outformats or "all" in outformats:
+            required_execs.append("pdfeps")
     if element == "sageplot":
-        required_execs = ['sage']
+        required_execs = ["sage"]
     install_hints = {
-        'xelatex':{
-            'Windows': 'See https://pretextbook.org/doc/guide/html/windows-cli-software.html',
-            'Darwin': '',
-            'Linux': ''},
-        'pdfsvg': {
-            'Windows': 'Follow the instructions at https://pretextbook.org/doc/guide/html/section-installing-pdf2svg.html to install pdf2svg',
-            'Darwin': '',
-            'Linux': 'You should be able to install pdf2svg with your package manager (e.g., `sudo apt install pdf2svg`.  See https://github.com/dawbarton/pdf2svg#pdf2svg.'},
-        'pdfpng': {
-            'Windows': 'See https:// pretextbook.org/doc/guide/html/windows-cli-software.html',
-            'Darwin': '',
-            'Linux': ''},
-        'pdfeps': {
-            'Windows': 'See https:// pretextbook.org/doc/guide/html/windows-cli-software.html',
-            'Darwin': '',
-            'Linux': ''},
-        'sage': {
-            'Windows': 'See https://doc.sagemath.org/html/en/installation/index.html#windows',
-            'Darwin': 'https://doc.sagemath.org/html/en/installation/index.html#macos',
-            'Linux': 'See https://doc.sagemath.org/html/en/installation/index.html#linux'},
-        'pageres': {
-            'Windows': 'See https:// pretextbook.org/doc/guide/html/windows-cli-software.html',
-            'Darwin': '',
-            'Linux': ''}
-        }
+        "xelatex": {
+            "Windows": "See https://pretextbook.org/doc/guide/html/windows-cli-software.html",
+            "Darwin": "",
+            "Linux": "",
+        },
+        "pdfsvg": {
+            "Windows": "Follow the instructions at https://pretextbook.org/doc/guide/html/section-installing-pdf2svg.html to install pdf2svg",
+            "Darwin": "",
+            "Linux": "You should be able to install pdf2svg with your package manager (e.g., `sudo apt install pdf2svg`.  See https://github.com/dawbarton/pdf2svg#pdf2svg.",
+        },
+        "pdfpng": {
+            "Windows": "See https:// pretextbook.org/doc/guide/html/windows-cli-software.html",
+            "Darwin": "",
+            "Linux": "",
+        },
+        "pdfeps": {
+            "Windows": "See https:// pretextbook.org/doc/guide/html/windows-cli-software.html",
+            "Darwin": "",
+            "Linux": "",
+        },
+        "sage": {
+            "Windows": "See https://doc.sagemath.org/html/en/installation/index.html#windows",
+            "Darwin": "https://doc.sagemath.org/html/en/installation/index.html#macos",
+            "Linux": "See https://doc.sagemath.org/html/en/installation/index.html#linux",
+        },
+        "pageres": {
+            "Windows": "See https:// pretextbook.org/doc/guide/html/windows-cli-software.html",
+            "Darwin": "",
+            "Linux": "",
+        },
+    }
     for required_exec in required_execs:
         if check_executable(required_exec) is None:
-            log.warning(f"In order to generate {element} into formats {outformats}, you must have {required_exec} installed, but this appears to be missing or configured incorrectly in pretext.ptx")
-            #print installation hints based on operating system and missing program.
+            log.warning(
+                f"In order to generate {element} into formats {outformats}, you must have {required_exec} installed, but this appears to be missing or configured incorrectly in pretext.ptx"
+            )
+            # print installation hints based on operating system and missing program.
             log.info(install_hints[required_exec][platform.system()])
 
-def no_project(task:str) -> bool:
-    '''
+
+def no_project(task: str) -> bool:
+    """
     Standard messages to be displayed when no project.ptx is found, customized by the "task" to be preformed.
-    '''
+    """
     if project_path() is None:
-        log.critical(f"Before you can {task} your PreTeXt project, you must be in a (sub)directory initialized with a project.ptx manifest.")
-        log.critical("Move to such a directory, use `pretext new` to create a new project, or `pretext init` to update existing project for use with the CLI.")
+        log.critical(
+            f"Before you can {task} your PreTeXt project, you must be in a (sub)directory initialized with a project.ptx manifest."
+        )
+        log.critical(
+            "Move to such a directory, use `pretext new` to create a new project, or `pretext init` to update existing project for use with the CLI."
+        )
         return True
     return False
 
-def show_target_hints(target_format:str, project, task:str):
-    '''
+
+def show_target_hints(target_format: str, project, task: str):
+    """
     This will give the user hints about why they have provided a bad target and make helpful suggestions for them to fix the problem.  We will only run this function when the target_name is not the name in any target in project.ptx.
-    '''
+    """
     # just in case this was called in the wrong place:
     if project.target(name=target_format) is not None:
         return
     # Otherwise continue with hints:
-    log.critical(f'There is not a target named "{target_format}" for this project.ptx manifest.')
-    if target_format in ['html', 'pdf', 'latex','epub','kindle','braille']:
+    log.critical(
+        f'There is not a target named "{target_format}" for this project.ptx manifest.'
+    )
+    if target_format in ["html", "pdf", "latex", "epub", "kindle", "braille"]:
         target_names = project.target_names(target_format)
         if len(target_names) == 1:
-            log.info(f'However, the target named "{target_names[0]}" has "{target_format}" as its format.  Try to {task} that instead or edit your project.ptx manifest.')
+            log.info(
+                f'However, the target named "{target_names[0]}" has "{target_format}" as its format.  Try to {task} that instead or edit your project.ptx manifest.'
+            )
         elif len(target_names) > 1:
-            log.info(f'However, the targets with names {target_names} have "{target_format}" as their format.  Try to {task} one of those instead or edit your project.ptx manifest.')
-        if target_format in ['epub', 'kindle']:
-            log.info(f"Instructions for setting up a target with the {target_format} format, including the external programs required, can be found in the PreTeXt guide: https://pretextbook.org/doc/guide/html/epub.html")
+            log.info(
+                f'However, the targets with names {target_names} have "{target_format}" as their format.  Try to {task} one of those instead or edit your project.ptx manifest.'
+            )
+        if target_format in ["epub", "kindle"]:
+            log.info(
+                f"Instructions for setting up a target with the {target_format} format, including the external programs required, can be found in the PreTeXt guide: https://pretextbook.org/doc/guide/html/epub.html"
+            )
     else:
-        log.info(f"The available targets to {task} are named: {project.target_names()}.  Try to {task} on of those instead or edit your proejct.ptx manifest.")
+        log.info(
+            f"The available targets to {task} are named: {project.target_names()}.  Try to {task} on of those instead or edit your proejct.ptx manifest."
+        )
+
 
 def npm_install():
     with working_directory(core.resources.path("script", "mjsre")):
         log.info("Attempting to install/update required node packages.")
         try:
-            subprocess.run('npm install', shell=True)
+            subprocess.run("npm install", shell=True)
         except Exception as e:
-            log.critical("Unable to install required npm packages.  Please see the documentation.")
+            log.critical(
+                "Unable to install required npm packages.  Please see the documentation."
+            )
             log.critical(e)
             log.debug("", exc_info=True)
 
-def remove_path(path:Path):
+
+def remove_path(path: Path):
     if path.is_file() or path.is_symlink():
         path.unlink()  # remove the file
     elif path.is_dir():
         shutil.rmtree(path)  # remove dir and all it contains
 
+
 def exit_command(mh):
-    '''
+    """
     Checks to see if anything (errors etc.) is in the memory handler.  If it is, reports that there are errors before the handler gets flushed.  Otherwise, adds a single blank line.
-    '''
+    """
     if len(mh.buffer) > 0:
         print("\n----------------------------------------------------")
         log.info("While running pretext, the following errors occured:\n")
         mh.flush()
-        print("----------------------------------------------------")      
+        print("----------------------------------------------------")
         sys.exit(1)
     else:
-        print('')
-    
+        print("")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,6 @@ pretext = 'pretext.cli:main'
 pytest = "^7.0.0"
 pytest-console-scripts = "^1.3.1"
 pytest-mock = "^3.8.2"
-
-[tool.poetry.group.dev.dependencies]
 black = "^22.12.0"
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ pytest = "^7.0.0"
 pytest-console-scripts = "^1.3.1"
 pytest-mock = "^3.8.2"
 
+[tool.poetry.group.dev.dependencies]
+black = "^22.12.0"
+
 [tool.pytest.ini_options]
 script_launch_mode = "subprocess"
 

--- a/scripts/build_package.py
+++ b/scripts/build_package.py
@@ -5,6 +5,7 @@ import zip_templates
 
 def main():
     import pretext
+
     print(f"Building package for version {pretext.VERSION}.")
 
     # ensure up-to-date "static" resources
@@ -16,5 +17,5 @@ def main():
     print("Completed poetry build of pretext")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/scripts/build_package.py
+++ b/scripts/build_package.py
@@ -1,5 +1,7 @@
 import subprocess
-import fetch_core, zip_templates
+import fetch_core
+import zip_templates
+
 
 def main():
     import pretext
@@ -12,6 +14,7 @@ def main():
     # Build package
     subprocess.run(["poetry", "build"], shell=True)
     print("Completed poetry build of pretext")
+
 
 if __name__ == '__main__':
     main()

--- a/scripts/fetch_core.py
+++ b/scripts/fetch_core.py
@@ -13,33 +13,36 @@ from remove_path import remove_path
 def main():
     # grab copy of necessary PreTeXtBook/pretext files from specified commit
 
-    print(
-        f"Requesting core PreTeXtBook/pretext commit {CORE_COMMIT} from GitHub.")
+    print(f"Requesting core PreTeXtBook/pretext commit {CORE_COMMIT} from GitHub.")
     pretext_dir = Path("pretext").resolve()
     r = requests.get(
-        f"https://github.com/PreTeXtBook/pretext/archive/{CORE_COMMIT}.zip")
+        f"https://github.com/PreTeXtBook/pretext/archive/{CORE_COMMIT}.zip"
+    )
     archive = zipfile.ZipFile(io.BytesIO(r.content))
     with tempfile.TemporaryDirectory() as tmpdirname:
         archive.extractall(tmpdirname)
         print("Creating zip of static folders")
         # Copy required folders to a single folder to be zipped:
-        for subdir in ['xsl', 'schema', 'script', 'css']:
+        for subdir in ["xsl", "schema", "script", "css"]:
             shutil.copytree(
-                Path(tmpdirname)/f"pretext-{CORE_COMMIT}"/subdir,
-                Path(tmpdirname)/"static"/subdir
+                Path(tmpdirname) / f"pretext-{CORE_COMMIT}" / subdir,
+                Path(tmpdirname) / "static" / subdir,
             )
-        shutil.make_archive("pretext/core/resources",
-                            'zip', Path(tmpdirname)/"static")
+        shutil.make_archive(
+            "pretext/core/resources", "zip", Path(tmpdirname) / "static"
+        )
         print("Copying new version of pretext.py to core directory")
-        remove_path(pretext_dir/"core"/"pretext.py")
+        remove_path(pretext_dir / "core" / "pretext.py")
         shutil.copyfile(
-            Path(tmpdirname).resolve() /
-            f"pretext-{CORE_COMMIT}"/"pretext"/"pretext.py",
-            Path("pretext")/"core"/"pretext.py",
+            Path(tmpdirname).resolve()
+            / f"pretext-{CORE_COMMIT}"
+            / "pretext"
+            / "pretext.py",
+            Path("pretext") / "core" / "pretext.py",
         )
 
     print("Successfully updated core PreTeXtBook/pretext resources from GitHub.")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/scripts/fetch_core.py
+++ b/scripts/fetch_core.py
@@ -1,34 +1,45 @@
-import requests, zipfile, io, shutil, tempfile, os
+import requests
+import zipfile
+import io
+import shutil
+import tempfile
+import os
 from pretext import CORE_COMMIT
 from pathlib import Path
 import os
 from remove_path import remove_path
 
+
 def main():
     # grab copy of necessary PreTeXtBook/pretext files from specified commit
 
-    print(f"Requesting core PreTeXtBook/pretext commit {CORE_COMMIT} from GitHub.")
+    print(
+        f"Requesting core PreTeXtBook/pretext commit {CORE_COMMIT} from GitHub.")
     pretext_dir = Path("pretext").resolve()
-    r = requests.get(f"https://github.com/PreTeXtBook/pretext/archive/{CORE_COMMIT}.zip")
+    r = requests.get(
+        f"https://github.com/PreTeXtBook/pretext/archive/{CORE_COMMIT}.zip")
     archive = zipfile.ZipFile(io.BytesIO(r.content))
     with tempfile.TemporaryDirectory() as tmpdirname:
         archive.extractall(tmpdirname)
         print("Creating zip of static folders")
         # Copy required folders to a single folder to be zipped:
-        for subdir in ['xsl','schema','script', 'css']:
+        for subdir in ['xsl', 'schema', 'script', 'css']:
             shutil.copytree(
                 Path(tmpdirname)/f"pretext-{CORE_COMMIT}"/subdir,
                 Path(tmpdirname)/"static"/subdir
             )
-        shutil.make_archive("pretext/core/resources", 'zip', Path(tmpdirname)/"static")
+        shutil.make_archive("pretext/core/resources",
+                            'zip', Path(tmpdirname)/"static")
         print("Copying new version of pretext.py to core directory")
         remove_path(pretext_dir/"core"/"pretext.py")
         shutil.copyfile(
-            Path(tmpdirname).resolve()/f"pretext-{CORE_COMMIT}"/"pretext"/"pretext.py",
+            Path(tmpdirname).resolve() /
+            f"pretext-{CORE_COMMIT}"/"pretext"/"pretext.py",
             Path("pretext")/"core"/"pretext.py",
         )
 
     print("Successfully updated core PreTeXtBook/pretext resources from GitHub.")
+
 
 if __name__ == '__main__':
     main()

--- a/scripts/prep_nightly.py
+++ b/scripts/prep_nightly.py
@@ -10,53 +10,64 @@ def commit_data(repo):
     url = f"https://api.github.com/repos/pretextbook/{repo}/commits"
     response = urlopen(url)
     data = json.loads(response.read())
-    lastcommit['date'] = datetime.strptime(
-        data[0]['commit']['committer']['date'], "%Y-%m-%dT%H:%M:%SZ")
-    lastcommit['sha'] = data[0]['sha']
+    lastcommit["date"] = datetime.strptime(
+        data[0]["commit"]["committer"]["date"], "%Y-%m-%dT%H:%M:%SZ"
+    )
+    lastcommit["sha"] = data[0]["sha"]
     return lastcommit
 
 
 def should_release(coredate, clidate):
     if (datetime.now() - coredate).days < 1:
         print(
-            f"There has been an update to core pretext in the last 24 hours, at {coredate}")
+            f"There has been an update to core pretext in the last 24 hours, at {coredate}"
+        )
         return True
     elif (datetime.now() - clidate).days < 1:
-        print(
-            f"There has been an update to the CLI in the last 24 hours, at {clidate}")
+        print(f"There has been an update to the CLI in the last 24 hours, at {clidate}")
         return True
     else:
         return True
 
 
 def main():
-    last_core_commit = commit_data('pretext')
-    last_cli_commit = commit_data('pretext-cli')
+    last_core_commit = commit_data("pretext")
+    last_cli_commit = commit_data("pretext-cli")
 
     # Check to see if there is nothing new to build and stop script if so.
-    if not(should_release(last_core_commit['date'], last_cli_commit['date'])):
-        print("No recent commits to pretext core of the CLI.  No nightly will be built.")
+    if not (should_release(last_core_commit["date"], last_cli_commit["date"])):
+        print(
+            "No recent commits to pretext core of the CLI.  No nightly will be built."
+        )
         return
 
     # Update core commit (temporarily):
-    for line in fileinput.input(Path(__file__).parent.parent/"pretext/__init__.py", inplace=True):
-        if 'CORE_COMMIT' in line:
-            print(line.replace(
-                line, f"CORE_COMMIT = '{last_core_commit['sha']}'".rstrip()))
+    for line in fileinput.input(
+        Path(__file__).parent.parent / "pretext/__init__.py", inplace=True
+    ):
+        if "CORE_COMMIT" in line:
+            print(
+                line.replace(
+                    line, f"CORE_COMMIT = '{last_core_commit['sha']}'".rstrip()
+                )
+            )
         else:
             print(line.rstrip())
 
     # Update version (temporarily) in pyproject.toml:
-    for line in fileinput.input(Path(__file__).parent.parent/"pyproject.toml", inplace=True):
+    for line in fileinput.input(
+        Path(__file__).parent.parent / "pyproject.toml", inplace=True
+    ):
         if line.startswith("version"):
             version = str(line.split('"')[1])
-            newversion = version+".dev"+datetime.now().strftime('%Y%m%d')
+            newversion = version + ".dev" + datetime.now().strftime("%Y%m%d")
             print(line.replace(line, f'version = "{newversion}"'.rstrip()))
         else:
             print(line.rstrip())
 
     # Need to wait to import build_package until now so it gets the updated version CORE_COMMIT and version.
     import build_package
+
     build_package.main()
 
     # Test package before deploying
@@ -78,5 +89,5 @@ def main():
     # subprocess.run(["poetry", "publish"], shell=True)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/scripts/prep_nightly.py
+++ b/scripts/prep_nightly.py
@@ -10,19 +10,24 @@ def commit_data(repo):
     url = f"https://api.github.com/repos/pretextbook/{repo}/commits"
     response = urlopen(url)
     data = json.loads(response.read())
-    lastcommit['date'] = datetime.strptime(data[0]['commit']['committer']['date'], "%Y-%m-%dT%H:%M:%SZ")
+    lastcommit['date'] = datetime.strptime(
+        data[0]['commit']['committer']['date'], "%Y-%m-%dT%H:%M:%SZ")
     lastcommit['sha'] = data[0]['sha']
     return lastcommit
 
-def should_release(coredate,clidate):
-    if (datetime.now() - coredate).days< 1:
-        print(f"There has been an update to core pretext in the last 24 hours, at {coredate}")
+
+def should_release(coredate, clidate):
+    if (datetime.now() - coredate).days < 1:
+        print(
+            f"There has been an update to core pretext in the last 24 hours, at {coredate}")
         return True
     elif (datetime.now() - clidate).days < 1:
-        print(f"There has been an update to the CLI in the last 24 hours, at {clidate}")
+        print(
+            f"There has been an update to the CLI in the last 24 hours, at {clidate}")
         return True
     else:
         return True
+
 
 def main():
     last_core_commit = commit_data('pretext')
@@ -35,20 +40,21 @@ def main():
 
     # Update core commit (temporarily):
     for line in fileinput.input(Path(__file__).parent.parent/"pretext/__init__.py", inplace=True):
-      if 'CORE_COMMIT' in line:
-        print(line.replace(line, f"CORE_COMMIT = '{last_core_commit['sha']}'".rstrip()))
-      else:
-        print(line.rstrip())
+        if 'CORE_COMMIT' in line:
+            print(line.replace(
+                line, f"CORE_COMMIT = '{last_core_commit['sha']}'".rstrip()))
+        else:
+            print(line.rstrip())
 
     # Update version (temporarily) in pyproject.toml:
     for line in fileinput.input(Path(__file__).parent.parent/"pyproject.toml", inplace=True):
-      if line.startswith("version"):
-        version = str(line.split('"')[1])
-        newversion = version+".dev"+datetime.now().strftime('%Y%m%d')
-        print(line.replace(line, f'version = "{newversion}"'.rstrip()))
-      else:
-        print(line.rstrip())
-    
+        if line.startswith("version"):
+            version = str(line.split('"')[1])
+            newversion = version+".dev"+datetime.now().strftime('%Y%m%d')
+            print(line.replace(line, f'version = "{newversion}"'.rstrip()))
+        else:
+            print(line.rstrip())
+
     # Need to wait to import build_package until now so it gets the updated version CORE_COMMIT and version.
     import build_package
     build_package.main()

--- a/scripts/release_alpha.py
+++ b/scripts/release_alpha.py
@@ -1,9 +1,12 @@
-import subprocess, pretext, git
+import subprocess
+import pretext
+import git
 import build_package
+
 
 def main():
     repo = git.Repo()
-    if repo.bare or repo.is_dirty() or len(repo.untracked_files)>0:
+    if repo.bare or repo.is_dirty() or len(repo.untracked_files) > 0:
         raise Exception("Must commit outstanding changes to project source.")
 
     build_package.main()
@@ -23,6 +26,7 @@ def main():
     repo.git.add("pyproject.toml")
     repo.index.commit("Bump version to new alpha")
     repo.remotes.origin.push()
+
 
 if __name__ == '__main__':
     main()

--- a/scripts/release_alpha.py
+++ b/scripts/release_alpha.py
@@ -28,5 +28,5 @@ def main():
     repo.remotes.origin.push()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/scripts/release_nightly.py
+++ b/scripts/release_nightly.py
@@ -7,24 +7,30 @@ import fileinput
 import pytest
 import tomli
 
+
 def commit_data(repo):
     lastcommit = {}
     url = f"https://api.github.com/repos/pretextbook/{repo}/commits"
     response = urlopen(url)
     data = json.loads(response.read())
-    lastcommit['date'] = datetime.strptime(data[0]['commit']['committer']['date'], "%Y-%m-%dT%H:%M:%SZ")
+    lastcommit['date'] = datetime.strptime(
+        data[0]['commit']['committer']['date'], "%Y-%m-%dT%H:%M:%SZ")
     lastcommit['sha'] = data[0]['sha']
     return lastcommit
 
-def should_release(coredate,clidate):
-    if (datetime.now() - coredate).days< 1:
-        print(f"There has been an update to core pretext in the last 24 hours, at {coredate}")
+
+def should_release(coredate, clidate):
+    if (datetime.now() - coredate).days < 1:
+        print(
+            f"There has been an update to core pretext in the last 24 hours, at {coredate}")
         return True
     elif (datetime.now() - clidate).days < 1:
-        print(f"There has been an update to the CLI in the last 24 hours, at {clidate}")
+        print(
+            f"There has been an update to the CLI in the last 24 hours, at {clidate}")
         return True
     else:
         return True
+
 
 def main():
     last_core_commit = commit_data('pretext')
@@ -37,20 +43,21 @@ def main():
 
     # Update core commit (temporarily):
     for line in fileinput.input(Path(__file__).parent.parent/"pretext/__init__.py", inplace=True):
-      if 'CORE_COMMIT' in line:
-        print(line.replace(line, f"CORE_COMMIT = '{last_core_commit['sha']}'".rstrip()))
-      else:
-        print(line.rstrip())
+        if 'CORE_COMMIT' in line:
+            print(line.replace(
+                line, f"CORE_COMMIT = '{last_core_commit['sha']}'".rstrip()))
+        else:
+            print(line.rstrip())
 
     # Update version (temporarily) in pyproject.toml:
     for line in fileinput.input(Path(__file__).parent.parent/"pyproject.toml", inplace=True):
-      if 'version' in line:
-        version = str(line.split('"')[1])
-        newversion = version+"-dev."+datetime.now().strftime('%Y%m%d%H%M%S')
-        print(line.replace(line, f'version = "{newversion}"'.rstrip()))
-      else:
-        print(line.rstrip())
-    
+        if 'version' in line:
+            version = str(line.split('"')[1])
+            newversion = version+"-dev."+datetime.now().strftime('%Y%m%d%H%M%S')
+            print(line.replace(line, f'version = "{newversion}"'.rstrip()))
+        else:
+            print(line.rstrip())
+
     # Need to wait to import build_package until now so it gets the updated version CORE_COMMIT and version.
     import build_package
     build_package.main()

--- a/scripts/release_nightly.py
+++ b/scripts/release_nightly.py
@@ -13,53 +13,64 @@ def commit_data(repo):
     url = f"https://api.github.com/repos/pretextbook/{repo}/commits"
     response = urlopen(url)
     data = json.loads(response.read())
-    lastcommit['date'] = datetime.strptime(
-        data[0]['commit']['committer']['date'], "%Y-%m-%dT%H:%M:%SZ")
-    lastcommit['sha'] = data[0]['sha']
+    lastcommit["date"] = datetime.strptime(
+        data[0]["commit"]["committer"]["date"], "%Y-%m-%dT%H:%M:%SZ"
+    )
+    lastcommit["sha"] = data[0]["sha"]
     return lastcommit
 
 
 def should_release(coredate, clidate):
     if (datetime.now() - coredate).days < 1:
         print(
-            f"There has been an update to core pretext in the last 24 hours, at {coredate}")
+            f"There has been an update to core pretext in the last 24 hours, at {coredate}"
+        )
         return True
     elif (datetime.now() - clidate).days < 1:
-        print(
-            f"There has been an update to the CLI in the last 24 hours, at {clidate}")
+        print(f"There has been an update to the CLI in the last 24 hours, at {clidate}")
         return True
     else:
         return True
 
 
 def main():
-    last_core_commit = commit_data('pretext')
-    last_cli_commit = commit_data('pretext-cli')
+    last_core_commit = commit_data("pretext")
+    last_cli_commit = commit_data("pretext-cli")
 
     # Check to see if there is nothing new to build and stop script if so.
-    if not(should_release(last_core_commit['date'], last_cli_commit['date'])):
-        print("No recent commits to pretext core of the CLI.  No nightly will be built.")
+    if not (should_release(last_core_commit["date"], last_cli_commit["date"])):
+        print(
+            "No recent commits to pretext core of the CLI.  No nightly will be built."
+        )
         return
 
     # Update core commit (temporarily):
-    for line in fileinput.input(Path(__file__).parent.parent/"pretext/__init__.py", inplace=True):
-        if 'CORE_COMMIT' in line:
-            print(line.replace(
-                line, f"CORE_COMMIT = '{last_core_commit['sha']}'".rstrip()))
+    for line in fileinput.input(
+        Path(__file__).parent.parent / "pretext/__init__.py", inplace=True
+    ):
+        if "CORE_COMMIT" in line:
+            print(
+                line.replace(
+                    line, f"CORE_COMMIT = '{last_core_commit['sha']}'".rstrip()
+                )
+            )
         else:
             print(line.rstrip())
 
     # Update version (temporarily) in pyproject.toml:
-    for line in fileinput.input(Path(__file__).parent.parent/"pyproject.toml", inplace=True):
-        if 'version' in line:
+    for line in fileinput.input(
+        Path(__file__).parent.parent / "pyproject.toml", inplace=True
+    ):
+        if "version" in line:
             version = str(line.split('"')[1])
-            newversion = version+"-dev."+datetime.now().strftime('%Y%m%d%H%M%S')
+            newversion = version + "-dev." + datetime.now().strftime("%Y%m%d%H%M%S")
             print(line.replace(line, f'version = "{newversion}"'.rstrip()))
         else:
             print(line.rstrip())
 
     # Need to wait to import build_package until now so it gets the updated version CORE_COMMIT and version.
     import build_package
+
     build_package.main()
 
     # Test package before deploying
@@ -75,11 +86,12 @@ def main():
         return
 
     import pretext
+
     print(f"Publishing nightly dev version {pretext.VERSION}")
 
     # Publish nightly
     subprocess.run(["poetry", "publish"], shell=True)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/scripts/release_stable.py
+++ b/scripts/release_stable.py
@@ -6,7 +6,7 @@ import tomli
 import build_package
 
 
-def main(level='patch'):
+def main(level="patch"):
     repo = git.Repo()
     if repo.bare or repo.is_dirty() or len(repo.untracked_files) > 0:
         raise Exception("Must commit outstanding changes to project source.")
@@ -19,9 +19,9 @@ def main(level='patch'):
 
     build_package.main()
 
-    with open(Path(__file__).parent.parent/'pyproject.toml', "rb") as f:
+    with open(Path(__file__).parent.parent / "pyproject.toml", "rb") as f:
         toml_dict = tomli.load(f)
-        stable_version = toml_dict['tool']['poetry']['version']
+        stable_version = toml_dict["tool"]["poetry"]["version"]
     print(f"Publishing stable {stable_version}")
 
     # Publish stable
@@ -39,10 +39,10 @@ def main(level='patch'):
     repo.remotes.origin.push(tag.path)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     try:
         level = sys.argv[1].lower()
     except IndexError:
         level = "patch"
-    assert level in ['major', 'minor', 'patch']
+    assert level in ["major", "minor", "patch"]
     main(level)

--- a/scripts/release_stable.py
+++ b/scripts/release_stable.py
@@ -1,11 +1,14 @@
-import subprocess, git, sys
+import subprocess
+import git
+import sys
 from pathlib import Path
 import tomli
 import build_package
 
+
 def main(level='patch'):
     repo = git.Repo()
-    if repo.bare or repo.is_dirty() or len(repo.untracked_files)>0:
+    if repo.bare or repo.is_dirty() or len(repo.untracked_files) > 0:
         raise Exception("Must commit outstanding changes to project source.")
 
     # Bump stable version
@@ -34,6 +37,7 @@ def main(level='patch'):
     repo.index.commit("Bump version to new alpha")
     repo.remotes.origin.push()
     repo.remotes.origin.push(tag.path)
+
 
 if __name__ == '__main__':
     try:

--- a/scripts/remove_path.py
+++ b/scripts/remove_path.py
@@ -1,7 +1,8 @@
 import shutil
 from pathlib import Path
 
-def remove_path(path:Path):
+
+def remove_path(path: Path):
     if path.is_file() or path.is_symlink():
         path.unlink()  # remove the file
     elif path.is_dir():

--- a/scripts/symlink_core.py
+++ b/scripts/symlink_core.py
@@ -1,10 +1,12 @@
-import sys, shutil
+import sys
+import shutil
 from pathlib import Path
 from remove_path import remove_path
 import pretext.core.resources
 
-def main(core_path:Path=Path("../pretext")):
-    for subdir in ['xsl','schema','script', 'css']:
+
+def main(core_path: Path = Path("../pretext")):
+    for subdir in ['xsl', 'schema', 'script', 'css']:
         original_path = (core_path/subdir).resolve()
         link_path = pretext.core.resources.path(subdir)
         remove_path(link_path)
@@ -15,6 +17,7 @@ def main(core_path:Path=Path("../pretext")):
     link_path.symlink_to(original_path)
 
     print(f"Linked local core pretext directory `{core_path}`")
+
 
 if __name__ == '__main__':
     try:

--- a/scripts/symlink_core.py
+++ b/scripts/symlink_core.py
@@ -6,20 +6,20 @@ import pretext.core.resources
 
 
 def main(core_path: Path = Path("../pretext")):
-    for subdir in ['xsl', 'schema', 'script', 'css']:
-        original_path = (core_path/subdir).resolve()
+    for subdir in ["xsl", "schema", "script", "css"]:
+        original_path = (core_path / subdir).resolve()
         link_path = pretext.core.resources.path(subdir)
         remove_path(link_path)
         link_path.symlink_to(original_path)
-    original_path = (core_path/"pretext"/"pretext.py").resolve()
-    link_path = Path('pretext')/'core'/"pretext.py"
+    original_path = (core_path / "pretext" / "pretext.py").resolve()
+    link_path = Path("pretext") / "core" / "pretext.py"
     remove_path(link_path)
     link_path.symlink_to(original_path)
 
     print(f"Linked local core pretext directory `{core_path}`")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     try:
         core_path = Path(sys.argv[1])
     except IndexError:

--- a/scripts/zip_templates.py
+++ b/scripts/zip_templates.py
@@ -5,10 +5,10 @@ from pathlib import Path
 
 
 def main():
-    static_template_path = Path('pretext')/'templates'/'resources'
-    print(f'Zipping templates from source into `{static_template_path}`.')
+    static_template_path = Path("pretext") / "templates" / "resources"
+    print(f"Zipping templates from source into `{static_template_path}`.")
 
-    for template_directory in glob.iglob('templates/*'):
+    for template_directory in glob.iglob("templates/*"):
         template_path = Path(template_directory)
         if template_path.is_dir():
             with tempfile.TemporaryDirectory() as temporary_directory:
@@ -18,31 +18,27 @@ def main():
                     temporary_path,
                     dirs_exist_ok=True,
                 )
-                template_files = ['project.ptx',
-                                  '.gitignore', 'codechat_config.yaml']
+                template_files = ["project.ptx", ".gitignore", "codechat_config.yaml"]
                 for template_file in template_files:
-                    copied_template_file = temporary_path/template_file
+                    copied_template_file = temporary_path / template_file
                     if not copied_template_file.is_file():
                         shutil.copyfile(
-                            Path('templates')/template_file,
+                            Path("templates") / template_file,
                             copied_template_file,
                         )
                 template_zip_basename = template_path.name
                 shutil.make_archive(
-                    static_template_path/template_zip_basename,
-                    'zip',
+                    static_template_path / template_zip_basename,
+                    "zip",
                     temporary_path,
                 )
-    for f in ['project.ptx', 'publication.ptx', '.gitignore']:
-        shutil.copyfile(
-            Path('templates')/f,
-            static_template_path/f
-        )
-    with open(static_template_path/"__init__.py", "w") as _:
+    for f in ["project.ptx", "publication.ptx", ".gitignore"]:
+        shutil.copyfile(Path("templates") / f, static_template_path / f)
+    with open(static_template_path / "__init__.py", "w") as _:
         pass
 
-    print(f'Templates successfully zipped into `{static_template_path}`.')
+    print(f"Templates successfully zipped into `{static_template_path}`.")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/scripts/zip_templates.py
+++ b/scripts/zip_templates.py
@@ -1,5 +1,8 @@
-import shutil, glob, tempfile
+import shutil
+import glob
+import tempfile
 from pathlib import Path
+
 
 def main():
     static_template_path = Path('pretext')/'templates'/'resources'
@@ -15,7 +18,8 @@ def main():
                     temporary_path,
                     dirs_exist_ok=True,
                 )
-                template_files = ['project.ptx', '.gitignore', 'codechat_config.yaml']
+                template_files = ['project.ptx',
+                                  '.gitignore', 'codechat_config.yaml']
                 for template_file in template_files:
                     copied_template_file = temporary_path/template_file
                     if not copied_template_file.is_file():
@@ -29,15 +33,16 @@ def main():
                     'zip',
                     temporary_path,
                 )
-    for f in ['project.ptx','publication.ptx','.gitignore']:
+    for f in ['project.ptx', 'publication.ptx', '.gitignore']:
         shutil.copyfile(
             Path('templates')/f,
             static_template_path/f
         )
-    with open(static_template_path/"__init__.py","w") as _:
+    with open(static_template_path/"__init__.py", "w") as _:
         pass
 
     print(f'Templates successfully zipped into `{static_template_path}`.')
+
 
 if __name__ == '__main__':
     main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,16 @@
-import subprocess, os, shutil, time, signal, platform, random, sys
+import subprocess
+import os
+import shutil
+import time
+import signal
+import platform
+import random
+import sys
 from tempfile import TemporaryDirectory
 from pathlib import Path
 from contextlib import contextmanager
-import requests, pytest
+import requests
+import pytest
 import pretext
 
 EXAMPLES_DIR = Path(__file__).parent/'examples'
@@ -10,112 +18,145 @@ EXAMPLES_DIR = Path(__file__).parent/'examples'
 PTX_CMD = shutil.which("pretext")
 PY_CMD = sys.executable
 
+
 @contextmanager
 def pretext_view(*args):
-    process = subprocess.Popen([PTX_CMD,'-v','debug','view', '--no-launch']+list(args))
-    time.sleep(3) # stall for possible build
+    process = subprocess.Popen(
+        [PTX_CMD, '-v', 'debug', 'view', '--no-launch']+list(args))
+    time.sleep(3)  # stall for possible build
     try:
         yield process
     finally:
         process.terminate()
         process.wait()
 
+
 def test_entry_points(script_runner):
-    ret = script_runner.run(PTX_CMD,'-v','debug', '-h')
+    ret = script_runner.run(PTX_CMD, '-v', 'debug', '-h')
     assert ret.success
-    assert subprocess.run([PY_CMD, '-m', 'pretext','-v','debug', '-h'], shell=True).returncode == 0
+    assert subprocess.run([PY_CMD, '-m', 'pretext', '-v',
+                           'debug', '-h'], shell=True).returncode == 0
+
 
 def test_version(script_runner):
-    ret = script_runner.run(PTX_CMD,'-v','debug', '--version')
+    ret = script_runner.run(PTX_CMD, '-v', 'debug', '--version')
     assert ret.stdout.strip() == pretext.VERSION
 
-def test_new(tmp_path:Path,script_runner):
-    assert script_runner.run(PTX_CMD,'-v','debug', 'new', cwd=tmp_path).success
+
+def test_new(tmp_path: Path, script_runner):
+    assert script_runner.run(PTX_CMD, '-v', 'debug',
+                             'new', cwd=tmp_path).success
     assert (tmp_path/'new-pretext-project'/'project.ptx').exists()
 
-def test_build(tmp_path:Path,script_runner):
-    assert script_runner.run(PTX_CMD,'-v','debug', 'new', '-d', '.', cwd=tmp_path).success
-    assert script_runner.run(PTX_CMD,'-v','debug', 'build', 'web', cwd=tmp_path).success
+
+def test_build(tmp_path: Path, script_runner):
+    assert script_runner.run(PTX_CMD, '-v', 'debug',
+                             'new', '-d', '.', cwd=tmp_path).success
+    assert script_runner.run(PTX_CMD, '-v', 'debug',
+                             'build', 'web', cwd=tmp_path).success
     assert (tmp_path/'output'/'web').exists()
-    assert script_runner.run(PTX_CMD,'-v','debug', 'build', 'subset', cwd=tmp_path).success
+    assert script_runner.run(PTX_CMD, '-v', 'debug',
+                             'build', 'subset', cwd=tmp_path).success
     assert (tmp_path/'output'/'subset').exists()
-    assert script_runner.run(PTX_CMD, 'build', 'print-latex', cwd=tmp_path).success
+    assert script_runner.run(
+        PTX_CMD, 'build', 'print-latex', cwd=tmp_path).success
     assert (tmp_path/'output'/'print-latex').exists()
-    assert script_runner.run(PTX_CMD,'-v','debug', 'build', '-g', cwd=tmp_path).success
+    assert script_runner.run(PTX_CMD, '-v', 'debug',
+                             'build', '-g', cwd=tmp_path).success
     assert (tmp_path/'generated-assets').exists()
     os.removedirs(tmp_path/'generated-assets')
-    assert script_runner.run(PTX_CMD,'-v','debug', 'build', '-g', 'webwork', cwd=tmp_path).success
+    assert script_runner.run(PTX_CMD, '-v', 'debug',
+                             'build', '-g', 'webwork', cwd=tmp_path).success
     assert (tmp_path/'generated-assets').exists()
 
-def test_init(tmp_path:Path,script_runner):
-    assert script_runner.run(PTX_CMD,'-v','debug', 'init', cwd=tmp_path).success
+
+def test_init(tmp_path: Path, script_runner):
+    assert script_runner.run(PTX_CMD, '-v', 'debug',
+                             'init', cwd=tmp_path).success
     assert (tmp_path/'project.ptx').exists()
     assert (tmp_path/'requirements.txt').exists()
     assert (tmp_path/'.gitignore').exists()
     assert (tmp_path/'publication'/'publication.ptx').exists()
-    assert len([*tmp_path.glob('project-*.ptx')]) == 0 # need to refresh
-    assert script_runner.run(PTX_CMD,'-v','debug', 'init', '-r', cwd=tmp_path).success
+    assert len([*tmp_path.glob('project-*.ptx')]) == 0  # need to refresh
+    assert script_runner.run(PTX_CMD, '-v', 'debug',
+                             'init', '-r', cwd=tmp_path).success
     assert len([*tmp_path.glob('project-*.ptx')]) > 0
     assert len([*tmp_path.glob('requirements-*.txt')]) > 0
     assert len([*tmp_path.glob('.gitignore-*')]) > 0
     assert len([*tmp_path.glob('publication/publication-*.ptx')]) > 0
 
-def test_generate_asymptote(tmp_path:Path,script_runner):
-    assert script_runner.run(PTX_CMD,'-v','debug', 'init', cwd=tmp_path).success
+
+def test_generate_asymptote(tmp_path: Path, script_runner):
+    assert script_runner.run(PTX_CMD, '-v', 'debug',
+                             'init', cwd=tmp_path).success
     (tmp_path/'source').mkdir()
-    shutil.copyfile(EXAMPLES_DIR/'asymptote.ptx',tmp_path/'source'/'main.ptx')
-    assert script_runner.run(PTX_CMD,'-v','debug','generate','asymptote', cwd=tmp_path).success
+    shutil.copyfile(EXAMPLES_DIR/'asymptote.ptx', tmp_path/'source'/'main.ptx')
+    assert script_runner.run(PTX_CMD, '-v', 'debug',
+                             'generate', 'asymptote', cwd=tmp_path).success
     assert (tmp_path/'generated-assets'/'asymptote'/'test.html').exists()
     os.remove(tmp_path/'generated-assets'/'asymptote'/'test.html')
-    assert script_runner.run(PTX_CMD,'-v','debug','generate','-x', 'test', cwd=tmp_path).success
+    assert script_runner.run(PTX_CMD, '-v', 'debug',
+                             'generate', '-x', 'test', cwd=tmp_path).success
     assert (tmp_path/'generated-assets'/'asymptote'/'test.html').exists()
     os.remove(tmp_path/'generated-assets'/'asymptote'/'test.html')
-    assert script_runner.run(PTX_CMD,'-v','debug','generate','asymptote','-t', 'web', cwd=tmp_path).success
+    assert script_runner.run(PTX_CMD, '-v', 'debug', 'generate',
+                             'asymptote', '-t', 'web', cwd=tmp_path).success
     os.remove(tmp_path/'generated-assets'/'asymptote'/'test.html')
 
+
 @pytest.mark.skip(reason="Waiting on upstream changes to interactive preview generation")
-def test_generate_interactive(tmp_path:Path,script_runner):
+def test_generate_interactive(tmp_path: Path, script_runner):
     int_path = tmp_path/'interactive'
-    shutil.copytree(EXAMPLES_DIR/'projects'/'interactive',int_path)
-    assert script_runner.run(PTX_CMD,'-v','debug','generate', cwd=int_path).success
-    preview_file = int_path/'generated-assets'/'preview'/'calcplot3d-probability-wavefunction.png'
+    shutil.copytree(EXAMPLES_DIR/'projects'/'interactive', int_path)
+    assert script_runner.run(PTX_CMD, '-v', 'debug',
+                             'generate', cwd=int_path).success
+    preview_file = int_path/'generated-assets' / \
+        'preview'/'calcplot3d-probability-wavefunction.png'
     assert preview_file.exists()
 
 
-def test_view(tmp_path:Path,script_runner):
+def test_view(tmp_path: Path, script_runner):
     os.chdir(tmp_path)
     port = random.randint(10_000, 65_536)
-    with pretext_view('-d','.','-p',f'{port}'):
+    with pretext_view('-d', '.', '-p', f'{port}'):
         assert requests.get(f'http://localhost:{port}/').status_code == 200
-    assert script_runner.run(PTX_CMD,'-v','debug',"new","-d",'1').success
+    assert script_runner.run(PTX_CMD, '-v', 'debug', "new", "-d", '1').success
     os.chdir(Path('1'))
-    assert script_runner.run(PTX_CMD,'-v','debug','build').success
+    assert script_runner.run(PTX_CMD, '-v', 'debug', 'build').success
     port = random.randint(10_000, 65_536)
-    with pretext_view('-p',f'{port}'):
+    with pretext_view('-p', f'{port}'):
         assert requests.get(f'http://localhost:{port}/').status_code == 200
     os.chdir(tmp_path)
-    assert script_runner.run(PTX_CMD,'-v','debug',"new","-d",'2').success
+    assert script_runner.run(PTX_CMD, '-v', 'debug', "new", "-d", '2').success
     os.chdir(Path('2'))
     port = random.randint(10_000, 65_536)
-    with pretext_view('-p',f'{port}','-b','-g'):
+    with pretext_view('-p', f'{port}', '-b', '-g'):
         assert requests.get(f'http://localhost:{port}/').status_code == 200
 
-def test_custom_xsl(tmp_path:Path,script_runner):
+
+def test_custom_xsl(tmp_path: Path, script_runner):
     custom_path = tmp_path/'custom'
-    shutil.copytree(EXAMPLES_DIR/'projects'/'custom-xsl',custom_path)
-    assert script_runner.run(PTX_CMD,'-v','debug','build', cwd=custom_path).success
+    shutil.copytree(EXAMPLES_DIR/'projects'/'custom-xsl', custom_path)
+    assert script_runner.run(PTX_CMD, '-v', 'debug',
+                             'build', cwd=custom_path).success
     assert (custom_path/'output'/'test').exists()
 
-def test_custom_webwork_server(tmp_path:Path,script_runner):
+
+def test_custom_webwork_server(tmp_path: Path, script_runner):
     custom_path = tmp_path/'custom'
-    shutil.copytree(EXAMPLES_DIR/'projects'/'custom-wwserver',custom_path)
-    result = script_runner.run(PTX_CMD,'-v','debug','generate','webwork', cwd=custom_path)
+    shutil.copytree(EXAMPLES_DIR/'projects'/'custom-wwserver', custom_path)
+    result = script_runner.run(
+        PTX_CMD, '-v', 'debug', 'generate', 'webwork', cwd=custom_path)
     assert result.success
     assert 'webwork-dev' in result.stderr
-    result = script_runner.run(PTX_CMD,'-v','debug','build', cwd=custom_path)
+    result = script_runner.run(
+        PTX_CMD, '-v', 'debug', 'build', cwd=custom_path)
     assert result.success
 
-def test_slideshow(tmp_path:Path,script_runner):
-    assert script_runner.run(PTX_CMD,'-v','debug', 'new', 'slideshow', '-d', '.', cwd=tmp_path).success
-    assert script_runner.run(PTX_CMD,'-v','debug', 'build', 'web', cwd=tmp_path).success
+
+def test_slideshow(tmp_path: Path, script_runner):
+    assert script_runner.run(
+        PTX_CMD, '-v', 'debug', 'new', 'slideshow', '-d', '.', cwd=tmp_path).success
+    assert script_runner.run(PTX_CMD, '-v', 'debug',
+                             'build', 'web', cwd=tmp_path).success
     assert (tmp_path/'output'/'web'/'slides.html').exists()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,7 @@ import requests
 import pytest
 import pretext
 
-EXAMPLES_DIR = Path(__file__).parent/'examples'
+EXAMPLES_DIR = Path(__file__).parent / "examples"
 
 PTX_CMD = shutil.which("pretext")
 PY_CMD = sys.executable
@@ -22,7 +22,8 @@ PY_CMD = sys.executable
 @contextmanager
 def pretext_view(*args):
     process = subprocess.Popen(
-        [PTX_CMD, '-v', 'debug', 'view', '--no-launch']+list(args))
+        [PTX_CMD, "-v", "debug", "view", "--no-launch"] + list(args)
+    )
     time.sleep(3)  # stall for possible build
     try:
         yield process
@@ -32,131 +33,144 @@ def pretext_view(*args):
 
 
 def test_entry_points(script_runner):
-    ret = script_runner.run(PTX_CMD, '-v', 'debug', '-h')
+    ret = script_runner.run(PTX_CMD, "-v", "debug", "-h")
     assert ret.success
-    assert subprocess.run([PY_CMD, '-m', 'pretext', '-v',
-                           'debug', '-h'], shell=True).returncode == 0
+    assert (
+        subprocess.run(
+            [PY_CMD, "-m", "pretext", "-v", "debug", "-h"], shell=True
+        ).returncode
+        == 0
+    )
 
 
 def test_version(script_runner):
-    ret = script_runner.run(PTX_CMD, '-v', 'debug', '--version')
+    ret = script_runner.run(PTX_CMD, "-v", "debug", "--version")
     assert ret.stdout.strip() == pretext.VERSION
 
 
 def test_new(tmp_path: Path, script_runner):
-    assert script_runner.run(PTX_CMD, '-v', 'debug',
-                             'new', cwd=tmp_path).success
-    assert (tmp_path/'new-pretext-project'/'project.ptx').exists()
+    assert script_runner.run(PTX_CMD, "-v", "debug", "new", cwd=tmp_path).success
+    assert (tmp_path / "new-pretext-project" / "project.ptx").exists()
 
 
 def test_build(tmp_path: Path, script_runner):
-    assert script_runner.run(PTX_CMD, '-v', 'debug',
-                             'new', '-d', '.', cwd=tmp_path).success
-    assert script_runner.run(PTX_CMD, '-v', 'debug',
-                             'build', 'web', cwd=tmp_path).success
-    assert (tmp_path/'output'/'web').exists()
-    assert script_runner.run(PTX_CMD, '-v', 'debug',
-                             'build', 'subset', cwd=tmp_path).success
-    assert (tmp_path/'output'/'subset').exists()
     assert script_runner.run(
-        PTX_CMD, 'build', 'print-latex', cwd=tmp_path).success
-    assert (tmp_path/'output'/'print-latex').exists()
-    assert script_runner.run(PTX_CMD, '-v', 'debug',
-                             'build', '-g', cwd=tmp_path).success
-    assert (tmp_path/'generated-assets').exists()
-    os.removedirs(tmp_path/'generated-assets')
-    assert script_runner.run(PTX_CMD, '-v', 'debug',
-                             'build', '-g', 'webwork', cwd=tmp_path).success
-    assert (tmp_path/'generated-assets').exists()
+        PTX_CMD, "-v", "debug", "new", "-d", ".", cwd=tmp_path
+    ).success
+    assert script_runner.run(
+        PTX_CMD, "-v", "debug", "build", "web", cwd=tmp_path
+    ).success
+    assert (tmp_path / "output" / "web").exists()
+    assert script_runner.run(
+        PTX_CMD, "-v", "debug", "build", "subset", cwd=tmp_path
+    ).success
+    assert (tmp_path / "output" / "subset").exists()
+    assert script_runner.run(PTX_CMD, "build", "print-latex", cwd=tmp_path).success
+    assert (tmp_path / "output" / "print-latex").exists()
+    assert script_runner.run(
+        PTX_CMD, "-v", "debug", "build", "-g", cwd=tmp_path
+    ).success
+    assert (tmp_path / "generated-assets").exists()
+    os.removedirs(tmp_path / "generated-assets")
+    assert script_runner.run(
+        PTX_CMD, "-v", "debug", "build", "-g", "webwork", cwd=tmp_path
+    ).success
+    assert (tmp_path / "generated-assets").exists()
 
 
 def test_init(tmp_path: Path, script_runner):
-    assert script_runner.run(PTX_CMD, '-v', 'debug',
-                             'init', cwd=tmp_path).success
-    assert (tmp_path/'project.ptx').exists()
-    assert (tmp_path/'requirements.txt').exists()
-    assert (tmp_path/'.gitignore').exists()
-    assert (tmp_path/'publication'/'publication.ptx').exists()
-    assert len([*tmp_path.glob('project-*.ptx')]) == 0  # need to refresh
-    assert script_runner.run(PTX_CMD, '-v', 'debug',
-                             'init', '-r', cwd=tmp_path).success
-    assert len([*tmp_path.glob('project-*.ptx')]) > 0
-    assert len([*tmp_path.glob('requirements-*.txt')]) > 0
-    assert len([*tmp_path.glob('.gitignore-*')]) > 0
-    assert len([*tmp_path.glob('publication/publication-*.ptx')]) > 0
+    assert script_runner.run(PTX_CMD, "-v", "debug", "init", cwd=tmp_path).success
+    assert (tmp_path / "project.ptx").exists()
+    assert (tmp_path / "requirements.txt").exists()
+    assert (tmp_path / ".gitignore").exists()
+    assert (tmp_path / "publication" / "publication.ptx").exists()
+    assert len([*tmp_path.glob("project-*.ptx")]) == 0  # need to refresh
+    assert script_runner.run(PTX_CMD, "-v", "debug", "init", "-r", cwd=tmp_path).success
+    assert len([*tmp_path.glob("project-*.ptx")]) > 0
+    assert len([*tmp_path.glob("requirements-*.txt")]) > 0
+    assert len([*tmp_path.glob(".gitignore-*")]) > 0
+    assert len([*tmp_path.glob("publication/publication-*.ptx")]) > 0
 
 
 def test_generate_asymptote(tmp_path: Path, script_runner):
-    assert script_runner.run(PTX_CMD, '-v', 'debug',
-                             'init', cwd=tmp_path).success
-    (tmp_path/'source').mkdir()
-    shutil.copyfile(EXAMPLES_DIR/'asymptote.ptx', tmp_path/'source'/'main.ptx')
-    assert script_runner.run(PTX_CMD, '-v', 'debug',
-                             'generate', 'asymptote', cwd=tmp_path).success
-    assert (tmp_path/'generated-assets'/'asymptote'/'test.html').exists()
-    os.remove(tmp_path/'generated-assets'/'asymptote'/'test.html')
-    assert script_runner.run(PTX_CMD, '-v', 'debug',
-                             'generate', '-x', 'test', cwd=tmp_path).success
-    assert (tmp_path/'generated-assets'/'asymptote'/'test.html').exists()
-    os.remove(tmp_path/'generated-assets'/'asymptote'/'test.html')
-    assert script_runner.run(PTX_CMD, '-v', 'debug', 'generate',
-                             'asymptote', '-t', 'web', cwd=tmp_path).success
-    os.remove(tmp_path/'generated-assets'/'asymptote'/'test.html')
+    assert script_runner.run(PTX_CMD, "-v", "debug", "init", cwd=tmp_path).success
+    (tmp_path / "source").mkdir()
+    shutil.copyfile(EXAMPLES_DIR / "asymptote.ptx", tmp_path / "source" / "main.ptx")
+    assert script_runner.run(
+        PTX_CMD, "-v", "debug", "generate", "asymptote", cwd=tmp_path
+    ).success
+    assert (tmp_path / "generated-assets" / "asymptote" / "test.html").exists()
+    os.remove(tmp_path / "generated-assets" / "asymptote" / "test.html")
+    assert script_runner.run(
+        PTX_CMD, "-v", "debug", "generate", "-x", "test", cwd=tmp_path
+    ).success
+    assert (tmp_path / "generated-assets" / "asymptote" / "test.html").exists()
+    os.remove(tmp_path / "generated-assets" / "asymptote" / "test.html")
+    assert script_runner.run(
+        PTX_CMD, "-v", "debug", "generate", "asymptote", "-t", "web", cwd=tmp_path
+    ).success
+    os.remove(tmp_path / "generated-assets" / "asymptote" / "test.html")
 
 
-@pytest.mark.skip(reason="Waiting on upstream changes to interactive preview generation")
+@pytest.mark.skip(
+    reason="Waiting on upstream changes to interactive preview generation"
+)
 def test_generate_interactive(tmp_path: Path, script_runner):
-    int_path = tmp_path/'interactive'
-    shutil.copytree(EXAMPLES_DIR/'projects'/'interactive', int_path)
-    assert script_runner.run(PTX_CMD, '-v', 'debug',
-                             'generate', cwd=int_path).success
-    preview_file = int_path/'generated-assets' / \
-        'preview'/'calcplot3d-probability-wavefunction.png'
+    int_path = tmp_path / "interactive"
+    shutil.copytree(EXAMPLES_DIR / "projects" / "interactive", int_path)
+    assert script_runner.run(PTX_CMD, "-v", "debug", "generate", cwd=int_path).success
+    preview_file = (
+        int_path
+        / "generated-assets"
+        / "preview"
+        / "calcplot3d-probability-wavefunction.png"
+    )
     assert preview_file.exists()
 
 
 def test_view(tmp_path: Path, script_runner):
     os.chdir(tmp_path)
     port = random.randint(10_000, 65_536)
-    with pretext_view('-d', '.', '-p', f'{port}'):
-        assert requests.get(f'http://localhost:{port}/').status_code == 200
-    assert script_runner.run(PTX_CMD, '-v', 'debug', "new", "-d", '1').success
-    os.chdir(Path('1'))
-    assert script_runner.run(PTX_CMD, '-v', 'debug', 'build').success
+    with pretext_view("-d", ".", "-p", f"{port}"):
+        assert requests.get(f"http://localhost:{port}/").status_code == 200
+    assert script_runner.run(PTX_CMD, "-v", "debug", "new", "-d", "1").success
+    os.chdir(Path("1"))
+    assert script_runner.run(PTX_CMD, "-v", "debug", "build").success
     port = random.randint(10_000, 65_536)
-    with pretext_view('-p', f'{port}'):
-        assert requests.get(f'http://localhost:{port}/').status_code == 200
+    with pretext_view("-p", f"{port}"):
+        assert requests.get(f"http://localhost:{port}/").status_code == 200
     os.chdir(tmp_path)
-    assert script_runner.run(PTX_CMD, '-v', 'debug', "new", "-d", '2').success
-    os.chdir(Path('2'))
+    assert script_runner.run(PTX_CMD, "-v", "debug", "new", "-d", "2").success
+    os.chdir(Path("2"))
     port = random.randint(10_000, 65_536)
-    with pretext_view('-p', f'{port}', '-b', '-g'):
-        assert requests.get(f'http://localhost:{port}/').status_code == 200
+    with pretext_view("-p", f"{port}", "-b", "-g"):
+        assert requests.get(f"http://localhost:{port}/").status_code == 200
 
 
 def test_custom_xsl(tmp_path: Path, script_runner):
-    custom_path = tmp_path/'custom'
-    shutil.copytree(EXAMPLES_DIR/'projects'/'custom-xsl', custom_path)
-    assert script_runner.run(PTX_CMD, '-v', 'debug',
-                             'build', cwd=custom_path).success
-    assert (custom_path/'output'/'test').exists()
+    custom_path = tmp_path / "custom"
+    shutil.copytree(EXAMPLES_DIR / "projects" / "custom-xsl", custom_path)
+    assert script_runner.run(PTX_CMD, "-v", "debug", "build", cwd=custom_path).success
+    assert (custom_path / "output" / "test").exists()
 
 
 def test_custom_webwork_server(tmp_path: Path, script_runner):
-    custom_path = tmp_path/'custom'
-    shutil.copytree(EXAMPLES_DIR/'projects'/'custom-wwserver', custom_path)
+    custom_path = tmp_path / "custom"
+    shutil.copytree(EXAMPLES_DIR / "projects" / "custom-wwserver", custom_path)
     result = script_runner.run(
-        PTX_CMD, '-v', 'debug', 'generate', 'webwork', cwd=custom_path)
+        PTX_CMD, "-v", "debug", "generate", "webwork", cwd=custom_path
+    )
     assert result.success
-    assert 'webwork-dev' in result.stderr
-    result = script_runner.run(
-        PTX_CMD, '-v', 'debug', 'build', cwd=custom_path)
+    assert "webwork-dev" in result.stderr
+    result = script_runner.run(PTX_CMD, "-v", "debug", "build", cwd=custom_path)
     assert result.success
 
 
 def test_slideshow(tmp_path: Path, script_runner):
     assert script_runner.run(
-        PTX_CMD, '-v', 'debug', 'new', 'slideshow', '-d', '.', cwd=tmp_path).success
-    assert script_runner.run(PTX_CMD, '-v', 'debug',
-                             'build', 'web', cwd=tmp_path).success
-    assert (tmp_path/'output'/'web'/'slides.html').exists()
+        PTX_CMD, "-v", "debug", "new", "slideshow", "-d", ".", cwd=tmp_path
+    ).success
+    assert script_runner.run(
+        PTX_CMD, "-v", "debug", "build", "web", cwd=tmp_path
+    ).success
+    assert (tmp_path / "output" / "web" / "slides.html").exists()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,8 @@ import os
 from pathlib import Path
 from pretext import utils
 
-def test_working_directory(tmp_path:Path):
+
+def test_working_directory(tmp_path: Path):
     os.chdir(tmp_path)
     subdir = Path('foobar')
     subdir.mkdir()
@@ -11,7 +12,8 @@ def test_working_directory(tmp_path:Path):
         assert Path().resolve().parent == tmp_path.resolve()
     # TODO check path returns afterward
 
-def test_project_path(tmp_path:Path):
+
+def test_project_path(tmp_path: Path):
     os.chdir(tmp_path)
     Path('project.ptx').write_text("")
     assert Path('project.ptx').exists()
@@ -21,4 +23,3 @@ def test_project_path(tmp_path:Path):
     subdir.mkdir()
     os.chdir(subdir)
     assert utils.project_path().resolve() == Path().resolve().parent
-

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,7 @@ from pretext import utils
 
 def test_working_directory(tmp_path: Path):
     os.chdir(tmp_path)
-    subdir = Path('foobar')
+    subdir = Path("foobar")
     subdir.mkdir()
     assert Path().resolve() == tmp_path.resolve()
     with utils.working_directory(subdir):
@@ -15,10 +15,10 @@ def test_working_directory(tmp_path: Path):
 
 def test_project_path(tmp_path: Path):
     os.chdir(tmp_path)
-    Path('project.ptx').write_text("")
-    assert Path('project.ptx').exists()
+    Path("project.ptx").write_text("")
+    assert Path("project.ptx").exists()
     assert utils.project_path().resolve() == tmp_path.resolve()
-    subdir = Path('foobar')
+    subdir = Path("foobar")
     print(subdir.resolve())
     subdir.mkdir()
     os.chdir(subdir)


### PR DESCRIPTION
Reformat the python codebase according to `pep8` rules. Using `ctrl+shift+I` in vscode should perform the exact same formatting that is in this PR. Subsequent applications of autoformatting shouldn't change anything.

This PR touches a lot and might be annoying to merge if there is current work on many branches, but hopefully that's not the case!

This PR also fixes some spelling errors, but makes no other changes.