### PR TITLE
Add: Use flake8 for linting.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,17 @@
+# ********************************
+# |docname| - Flake8 configuration
+# ********************************
+# See the `docs <https://flake8.pycqa.org/en/latest/user/configuration.html>`_ for more details.
+[flake8]
+# Although there is a `max-doc-length <https://flake8.pycqa.org/en/latest/user/options.html#cmdoption-flake8-max-doc-length>`_, setting this still produces lots of error about long lines, even if those lines are just a comment. The docs on `max-line-length <https://flake8.pycqa.org/en/latest/user/options.html#cmdoption-flake8-max-line-length>`_ states that it applies to ALL lines -- including comments -- unless they contain a URL or a string. So, set this to allow long comments.
+max-line-length = 50000
+
+extend-ignore =
+    # Black formats this differently.
+    E203
+
+# Exclude generated files and files from the pretext repo.
+exclude =
+    pretext/core/
+    output
+    .venv

--- a/.github/workflows/test-on-push.yml
+++ b/.github/workflows/test-on-push.yml
@@ -32,6 +32,10 @@ jobs:
       run: |
         python -m poetry run black --check --diff $(git ls-files "*.py")
 
+    - name: Check for lint
+      run: |
+        python -m poetry run flake8
+
   build:
     strategy:
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 A package for authoring and building [PreTeXt](https://pretextbook.org) documents.
 
-- GitHub: <https://github.com/PreTeXtBook/pretext-cli/>
+-   GitHub: <https://github.com/PreTeXtBook/pretext-cli/>
 
 ## Documentation and examples for authors/publishers
 
 Most documentation for PreTeXt authors and publishers is available at:
 
-- <https://pretextbook.org/doc/guide/html/>
+-   <https://pretextbook.org/doc/guide/html/>
 
 Authors and publishers may also find the examples catalog useful as well:
 
-- <https://pretextbook.org/examples.html>
+-   <https://pretextbook.org/examples.html>
 
 We have a few notes below (TODO: publish these in the Guide).
 
@@ -38,10 +38,10 @@ python3 -V
 
 If you don't have a compatible Python available, try one of these:
 
-- https://www.python.org/downloads/
-  - Windows warning: Be sure to select the option adding Python to your Path.
-- https://github.com/pyenv/pyenv#installation (Mac/Linux)
-- https://github.com/pyenv-win/pyenv-win#installation (Windows)
+-   https://www.python.org/downloads/
+    -   Windows warning: Be sure to select the option adding Python to your Path.
+-   https://github.com/pyenv/pyenv#installation (Mac/Linux)
+-   https://github.com/pyenv-win/pyenv-win#installation (Windows)
 
 #### Installing PreTeXt-CLI
 
@@ -52,7 +52,7 @@ run (replacing `python` with `python3` if necessary):
 python -m pip install --user pretext
 ```
 
-(It's possible you will get an error like 
+(It's possible you will get an error like
 `error: invalid command 'bdist_wheel'`
 — good news, you can ignore it!)
 
@@ -78,10 +78,11 @@ subcommands like `pretext new` and `pretext build`.
 We install as much as we can with the `pip install` command, but depending on your machine
 you may require some extra software:
 
-- [TeXLive](https://www.tug.org/texlive/)
-- [pdftoppm/Ghostscript](https://github.com/abarker/pdfCropMargins/blob/master/doc/installing_pdftoppm_and_ghostscript.rst)
+-   [TeXLive](https://www.tug.org/texlive/)
+-   [pdftoppm/Ghostscript](https://github.com/abarker/pdfCropMargins/blob/master/doc/installing_pdftoppm_and_ghostscript.rst)
 
 #### Upgrading PreTeXt-CLI
+
 If you have an existing installation and you want to upgrade to a more recent version, you can run:
 
 ```
@@ -94,8 +95,8 @@ Custom XSL is not encouraged for most authors, but (for example) developers work
 bleeding-edge XSL from core PreTeXt may want to call XSL different from that
 which is shipped with a fixed version of the CLI. This may be accomplished by
 adding an `<xsl/>` element to your target with a relative (to `project.ptx`) or
-absolute path to the desired XSL. *(Note: this XSL must only import
-other XSL files in the same directory or within subdirectories.)*
+absolute path to the desired XSL. _(Note: this XSL must only import
+other XSL files in the same directory or within subdirectories.)_
 
 For example:
 
@@ -126,14 +127,15 @@ Similarly, `entities.ent` may be used:
 ]>
 ```
 
-*Note: previously this was achieved with a `pretext-href` attribute - this is now deprecated and will be removed in a future release.*
+_Note: previously this was achieved with a `pretext-href` attribute - this is now deprecated and will be removed in a future release._
 
 ---
 
 ## Development
+
 **Note.** The remainder of this documentation is intended only for those interested
-in contributing to the developement of this project.  Anyone who simply wishes to
-*use* the PreTeXt-CLI can stop reading here. 
+in contributing to the development of this project. Anyone who simply wishes to
+_use_ the PreTeXt-CLI can stop reading here.
 
 From the "Clone or Download" button on GitHub, copy the `REPO_URL` into the below
 command to clone the project.
@@ -154,7 +156,7 @@ The `pyenv` tool for Linux automates the process of running the correct
 version of Python when working on this project (even if you have
 other versions of Python installed on your system).
 
-- https://github.com/pyenv/pyenv#installation
+-   https://github.com/pyenv/pyenv#installation
 
 Run the following, replacing `PYTHON_VERSION` with your desired version.
 
@@ -164,9 +166,9 @@ pyenv install PYTHON_VERSION
 
 Then follow these instructions to install `poetry`.
 
-- https://python-poetry.org/docs/#installation
-    - Note 2022/06/21: you may ignore "This installer is deprecated". See
-      [python-poetry/poetry/issues/4128](https://github.com/python-poetry/poetry/issues/4128)
+-   https://python-poetry.org/docs/#installation
+    -   Note 2022/06/21: you may ignore "This installer is deprecated". See
+        [python-poetry/poetry/issues/4128](https://github.com/python-poetry/poetry/issues/4128)
 
 Then you should be able to install dependencies into a virtual environment
 with this command.
@@ -211,10 +213,10 @@ pr pretext --version  # returns version being developed
 #### Steps on Windows
 
 In windows, you can either use the bash shell and follow the directions above,
-or try [pyenv-win](https://github.com/pyenv-win/pyenv-win#installation).  In
+or try [pyenv-win](https://github.com/pyenv-win/pyenv-win#installation). In
 the latter case, make sure to follow all the installation instructions, including
-the **Finish the installation**.  Then proceed to follow the directions above to
-install a version of python matching `.pyproject.toml`.  Finally, you may then need
+the **Finish the installation**. Then proceed to follow the directions above to
+install a version of python matching `pyproject.toml`. Finally, you may then need
 to manually add that version of python to your path.
 
 ### Updating dependencies
@@ -262,13 +264,16 @@ poetry run python scripts/zip_templates.py
 
 ### Formatting code before a commit
 
-All `.py` files are formatted with the `black` python formatter. Proper formatting
-is enforced by checks in the Continuous Integration framework. Before you commit code,
-you should make sure it is formatted with `black` by running the following command (on linux or mac)
+All `.py` files are formatted with the [black](https://black.readthedocs.io/en/stable/)
+python formatter and checked by [flake8](https://flake8.pycqa.org/en/latest/).
+Proper formatting is enforced by checks in the Continuous Integration framework.
+Before you commit code, you should make sure it is formatted with `black` and
+passes `flake8` by running the following commands (on linux or mac)
 from the _root_ project folder (most likely `pretext-cli`).
 
 ```
-poetry run black $(git ls-files "*.py")
+poetry run black .
+poetry run flake8
 ```
 
 ### Testing
@@ -317,11 +322,12 @@ poetry run python scripts/release_stable.py major # +1.0.0
 ## About
 
 ### PreTeXt-CLI Team
-- [Oscar Levin](https://math.oscarlevin.com/) is co-creator and lead developer of PreTeXt-CLI.
-- [Steven Clontz](https://clontz.org/) is co-creator and a regular contributor of PreTeXt-CLI.
-- Development of PreTeXt-CLI would not be possible without the frequent 
-  [contributions](https://github.com/PreTeXtBook/pretext-cli/graphs/contributors) of the
-  wider [PreTeXt-Runestone Open Source Ecosystem](https://prose.runestone.academy).
+
+-   [Oscar Levin](https://math.oscarlevin.com/) is co-creator and lead developer of PreTeXt-CLI.
+-   [Steven Clontz](https://clontz.org/) is co-creator and a regular contributor of PreTeXt-CLI.
+-   Development of PreTeXt-CLI would not be possible without the frequent
+    [contributions](https://github.com/PreTeXtBook/pretext-cli/graphs/contributors) of the
+    wider [PreTeXt-Runestone Open Source Ecosystem](https://prose.runestone.academy).
 
 ### A note and special thanks
 
@@ -333,5 +339,6 @@ As such, versions of this project before 1.0 are released on PyPI under the
 name `pretextbook`, while versions 1.0 and later are released as `pretext`.
 
 ### About PreTeXt
+
 The development of [PreTeXt's core](https://github.com/PreTeXtBook/pretext)
 is led by [Rob Beezer](http://buzzard.ups.edu/).

--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -600,7 +600,7 @@ def view(
                 subdir = directory.relative_to(Path.home())
             except ValueError:
                 subdir = ""
-            log.info(f"Directory can be previewed at the following link at any time:")
+            log.info("Directory can be previewed at the following link at any time:")
             log.info(f"    https://cocalc.com/{utils.cocalc_project_id()}/raw/{subdir}")
             return
         port = port or 8000
@@ -621,7 +621,7 @@ def view(
             subdir = target.output_dir().relative_to(Path.home())
         except ValueError:
             subdir = ""
-        log.info(f"Built project can be previewed at the following link at any time:")
+        log.info("Built project can be previewed at the following link at any time:")
         log.info(f"    https://cocalc.com/{utils.cocalc_project_id()}/raw/{subdir}")
         return
     port = port or target.port()

--- a/pretext/utils.py
+++ b/pretext/utils.py
@@ -21,7 +21,7 @@ import typing as t
 from lxml import etree as ET
 from typing import Optional
 
-from . import core
+from . import core, templates
 
 # Get access to logger
 log = logging.getLogger("ptxlogger")
@@ -275,7 +275,6 @@ def run_server(
     watch_callback=lambda: None,
     no_launch: bool = False,
 ):
-    binding = binding_for_access(access)
     threading.Thread(
         target=lambda: serve_forever(directory, access, port, no_launch), daemon=True
     ).start()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ pytest-console-scripts = "^1.3.1"
 pytest-mock = "^3.8.2"
 black = "^22.12.0"
 codechat-server = "^0.2.9"
+flake8 = "^6.0.0"
 
 [tool.pytest.ini_options]
 script_launch_mode = "subprocess"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,6 @@ import sys
 from pathlib import Path
 from contextlib import contextmanager
 import requests
-import pytest
 import pretext
 
 EXAMPLES_DIR = Path(__file__).parent / "examples"


### PR DESCRIPTION
Per the discussion in https://github.com/PreTeXtBook/pretext-cli/pull/370#issuecomment-1353404886.

Thoughts:
- I suggest that I open a separate PR with fixes for all the issues flake8 complains about, so we can discuss which merit fixing and which should be ignored before merging this PR.
- We should ignore lint issues in `core/pretext.py`, since the source comes from another repo. Are there any other files that come from elsewhere and should therefore be ignored?

Output from flake8
=============
```
.\pretext\build.py:48:23: F541 f-string is missing placeholders
.\pretext\build.py:75:23: F541 f-string is missing placeholders
.\pretext\build.py:104:23: F541 f-string is missing placeholders
.\pretext\build.py:138:23: F541 f-string is missing placeholders
.\pretext\build.py:168:23: F541 f-string is missing placeholders
.\pretext\build.py:196:23: F541 f-string is missing placeholders
.\pretext\build.py:229:23: F541 f-string is missing placeholders
.\pretext\cli.py:1:1: F401 'concurrent.futures.process._threads_wakeups' imported but unused
.\pretext\cli.py:2:1: F401 'pickle.FALSE' imported but unused
.\pretext\cli.py:15:1: F811 redefinition of unused 'shutil' from line 8
.\pretext\cli.py:185:21: F541 f-string is missing placeholders
.\pretext\cli.py:244:13: F541 f-string is missing placeholders
.\pretext\cli.py:309:14: F541 f-string is missing placeholders
.\pretext\cli.py:311:9: F541 f-string is missing placeholders
.\pretext\cli.py:465:20: E711 comparison to None should be 'if cond is None:'
.\pretext\core\__init__.py:2:5: F403 'from .pretext import *' used; unable to detect undefined names
.\pretext\core\__init__.py:11:1: F405 'set_ptx_path' may be undefined, or defined from star imports: .pretext
.\pretext\generate.py:6:1: F401 'typing.Optional' imported but unused
.\pretext\generate.py:65:31: F541 f-string is missing placeholders
.\pretext\generate.py:126:27: F541 f-string is missing placeholders
.\pretext\generate.py:185:27: F541 f-string is missing placeholders
.\pretext\generate.py:224:27: F541 f-string is missing placeholders
.\pretext\generate.py:255:27: F541 f-string is missing placeholders
.\pretext\generate.py:291:27: F541 f-string is missing placeholders
.\pretext\generate.py:325:27: F541 f-string is missing placeholders
.\pretext\project.py:225:17: E722 do not use bare 'except'
.\pretext\project.py:362:23: F541 f-string is missing placeholders
.\pretext\project.py:470:13: E722 do not use bare 'except'
.\pretext\project.py:529:18: F541 f-string is missing placeholders
.\pretext\project.py:551:9: E722 do not use bare 'except'
.\pretext\project.py:557:33: F541 f-string is missing placeholders
.\pretext\utils.py:3:1: F401 'glob' imported but unused
.\pretext\utils.py:13:1: F811 redefinition of unused 'subprocess' from line 1
.\pretext\utils.py:17:23: E401 multiple imports on one line
.\pretext\utils.py:50:16: E711 comparison to None should be 'if cond is None:'
.\pretext\utils.py:67:14: F821 undefined name 'templates'
.\pretext\utils.py:75:16: E711 comparison to None should be 'if cond is None:'
.\pretext\utils.py:89:16: E711 comparison to None should be 'if cond is None:'
.\pretext\utils.py:97:16: E711 comparison to None should be 'if cond is None:'
.\pretext\utils.py:151:5: E266 too many leading '#' for block comment
.\pretext\utils.py:173:5: E722 do not use bare 'except'
.\pretext\utils.py:186:9: E306 expected 1 blank line before a nested definition, found 0
.\pretext\utils.py:253:21: F541 f-string is missing placeholders
.\pretext\utils.py:257:30: F541 f-string is missing placeholders
.\pretext\utils.py:275:5: F841 local variable 'binding' is assigned to but never used
.\pretext\utils.py:478:49: E741 ambiguous variable name 'l'
.\pretext\utils.py:479:44: E741 ambiguous variable name 'l'
.\pretextbook\setup.py:6:1: F821 undefined name 'setup'
.\scripts\fetch_core.py:9:1: F811 redefinition of unused 'os' from line 6
.\scripts\fetch_core.py:9:1: F401 'os' imported but unused
.\scripts\release_nightly.py:8:1: F401 'tomli' imported but unused
.\scripts\release_nightly.py:84:5: E722 do not use bare 'except'
.\scripts\symlink_core.py:2:1: F401 'shutil' imported but unused
.\setup.py:6:1: F821 undefined name 'setup'
.\tests\test_cli.py:6:1: F401 'signal' imported but unused
.\tests\test_cli.py:7:1: F401 'platform' imported but unused
.\tests\test_cli.py:10:1: F401 'tempfile.TemporaryDirectory' imported but unused
.\tests\test_xml_overlay.py:2:1: F401 'typing as t' imported but unused
```