### PR TITLE
Fix bug introduced by code_chat function

### DIFF
--- a/pretext/build.py
+++ b/pretext/build.py
@@ -41,7 +41,7 @@ def html(
                 output.as_posix(),
             )
             codechat.map_path_to_xml_id(
-                ptxfile, utils.project_path(), output.as_posix()
+                ptxfile, utils.project_path(ptxfile), output.as_posix()
             )
         except Exception as e:
             log.critical(e)


### PR DESCRIPTION
The codechat function needed the project path, but where called it grabbed the project path of the temporary directory (sometimes at least, when `pretext build -g` was run).  Easy fix was to pass `ptxfile` to the `project_path()` function. 