### PR TITLE
fix project_path in case it has spaces

### DIFF
--- a/pretext/codechat.py
+++ b/pretext/codechat.py
@@ -17,6 +17,7 @@ import json  # dumps
 import pathlib  # Path
 import sys  # platform
 import urllib.parse  # urlparse
+import urllib.request # pathname2url
 
 # Third-party imports
 # -------------------
@@ -48,7 +49,7 @@ def map_path_to_xml_id(
     # A path to the root XML file in the pretext book being processed.
     xml: str,
     # A path to the project directory, which (should) contain ``codechat_config.yaml``.
-    project_path: str,
+    project_path: pathlib.Path,
     # A path to the destination or output directory. The resulting JSON file will be stored there.
     dest_dir: str,
 ) -> None:
@@ -78,6 +79,12 @@ def map_path_to_xml_id(
         if isinstance(ret, ET._Element):
             ret.attrib[xml_base_attrib] = href
         return ret
+
+    # Clean up project_path in case it has spaces.
+    project_path = urllib.request.pathname2url(str(project_path))
+    # Remove two leading slashes if on windows.
+    if is_win:
+        project_path = project_path[3:]  
 
     # Load the XML, performing xincludes using this loader.
     huge_parser = ET.XMLParser(huge_tree=True)

--- a/pretext/codechat.py
+++ b/pretext/codechat.py
@@ -17,7 +17,7 @@ import json  # dumps
 import pathlib  # Path
 import sys  # platform
 import urllib.parse  # urlparse
-import urllib.request # pathname2url
+import urllib.request  # pathname2url
 
 # Third-party imports
 # -------------------
@@ -84,7 +84,7 @@ def map_path_to_xml_id(
     project_path = urllib.request.pathname2url(str(project_path))
     # Remove two leading slashes if on windows.
     if is_win:
-        project_path = project_path[3:]  
+        project_path = project_path[3:]
 
     # Load the XML, performing xincludes using this loader.
     huge_parser = ET.XMLParser(huge_tree=True)


### PR DESCRIPTION
This should fix issue reported https://groups.google.com/g/pretext-support/c/A4h7OO7zfX4.  Heads up @bjones1, I added a step in the codechat module that cleans up `project_path` so it matches what `urllib.parse` gives when the path contains spaces.  Feel free to modify this on a new PR if you see a safer way to accomplish this.