### PR TITLE
Alternative fix to handling spaces in path names

### DIFF
--- a/pretext/codechat.py
+++ b/pretext/codechat.py
@@ -17,6 +17,7 @@ import json  # dumps
 import pathlib  # Path
 import sys  # platform
 import urllib.parse  # urlparse
+import urllib.request # pathname2url
 
 # Third-party imports
 # -------------------
@@ -48,7 +49,7 @@ def map_path_to_xml_id(
     # A path to the root XML file in the pretext book being processed.
     xml: str,
     # A path to the project directory, which (should) contain ``codechat_config.yaml``.
-    project_path: str,
+    project_path: pathlib.Path,
     # A path to the destination or output directory. The resulting JSON file will be stored there.
     dest_dir: str,
 ) -> None:
@@ -78,6 +79,12 @@ def map_path_to_xml_id(
         if isinstance(ret, ET._Element):
             ret.attrib[xml_base_attrib] = href
         return ret
+
+    # Clean up project_path in case it has spaces.
+    project_path = urllib.request.pathname2url(str(project_path))
+    # Remove two leading slashes if on windows.
+    if is_win:
+        project_path = project_path[3:]  
 
     # Load the XML, performing xincludes using this loader.
     huge_parser = ET.XMLParser(huge_tree=True)

--- a/pretext/codechat.py
+++ b/pretext/codechat.py
@@ -17,7 +17,6 @@ import json  # dumps
 import pathlib  # Path
 import sys  # platform
 import urllib.parse  # urlparse
-import urllib.request  # pathname2url
 
 # Third-party imports
 # -------------------
@@ -80,12 +79,6 @@ def map_path_to_xml_id(
             ret.attrib[xml_base_attrib] = href
         return ret
 
-    # Clean up project_path in case it has spaces.
-    project_path = urllib.request.pathname2url(str(project_path))
-    # Remove two leading slashes if on windows.
-    if is_win:
-        project_path = project_path[3:]
-
     # Load the XML, performing xincludes using this loader.
     huge_parser = ET.XMLParser(huge_tree=True)
     src_tree = ET.parse(xml, parser=huge_parser)
@@ -106,6 +99,8 @@ def map_path_to_xml_id(
             # On Windows, this produces ``path == "/C:/path/to/file.ptx"``. Remove the slash.
             if is_win:
                 path = path[1:]
+            # Decode the URL-encoded filename.
+            path = urllib.parse.unquote(path)
             # Use ``resolve()`` to standardize capitalization on Windows.
             stdpath = pathlib.Path(path).resolve()
             # Make this path relative to the project directory, to avoid writing potentially confidential information (username / local filesystem paths) to the mapping file, which might be published to the web.

--- a/pretext/codechat.py
+++ b/pretext/codechat.py
@@ -17,7 +17,7 @@ import json  # dumps
 import pathlib  # Path
 import sys  # platform
 import urllib.parse  # urlparse
-import urllib.request # pathname2url
+import urllib.request  # pathname2url
 
 # Third-party imports
 # -------------------
@@ -84,7 +84,7 @@ def map_path_to_xml_id(
     project_path = urllib.request.pathname2url(str(project_path))
     # Remove two leading slashes if on windows.
     if is_win:
-        project_path = project_path[3:]  
+        project_path = project_path[3:]
 
     # Load the XML, performing xincludes using this loader.
     huge_parser = ET.XMLParser(huge_tree=True)

--- a/templates/demo/source/ch-first with spaces.ptx
+++ b/templates/demo/source/ch-first with spaces.ptx
@@ -2,7 +2,7 @@
 <!-- Chapters are enclosed with <chapter> tags. Use xml:id to -->
 <!-- uniquely identify the chapter.  The @xmlns:xi attribute  -->
 <!-- is needed if you use xi:include in this file             -->
-<chapter xml:id="ch-first" xmlns:xi="http://www.w3.org/2001/XInclude">
+<chapter xml:id="ch-first-without-spaces" xmlns:xi="http://www.w3.org/2001/XInclude">
 
 <!-- Change title when you have one: -->
   <title>My First Chapter</title>

--- a/templates/demo/source/main.ptx
+++ b/templates/demo/source/main.ptx
@@ -27,7 +27,7 @@
     <!-- possible structure of the book.  Once you know what the   -->
     <!-- title of the chapter is, rename the file something based  -->
     <!-- on the title (ch-shorttitle.ptx) both here and on disk    -->
-    <xi:include href="./ch-first.ptx" />
+    <xi:include href="./ch-first%20with%20spaces.ptx" />
     <xi:include href="./ch-empty.ptx"/>
     <!-- Of course you will want to add more chapters as you proceed-->
 
@@ -36,7 +36,7 @@
     <!-- We recommend keeping this handy, and commenting it out    -->
     <!-- when you show off your own work.                          -->
     <xi:include href="./ch-features.ptx" />
-  
+
     <!-- This chapter includes several features that require pregeneration   -->
     <!-- of assets with `pretext generate` or similar. Some features require -->
     <!-- internet access; others require local installs not automatically    -->

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,13 +55,15 @@ def test_new(tmp_path: Path, script_runner):
 
 
 def test_build(tmp_path: Path, script_runner):
+    path_with_spaces = "test path with spaces"
+    project_path = tmp_path / path_with_spaces
     assert script_runner.run(
-        PTX_CMD, "-v", "debug", "new", "demo", "-d", ".", cwd=tmp_path
+        PTX_CMD, "-v", "debug", "new", "demo", "-d", path_with_spaces, cwd=tmp_path
     ).success
     assert script_runner.run(
-        PTX_CMD, "-v", "debug", "build", "web", cwd=tmp_path
+        PTX_CMD, "-v", "debug", "build", "web", cwd=project_path
     ).success
-    web_path = tmp_path / "output" / "web"
+    web_path = project_path / "output" / "web"
     assert web_path.exists()
     mapping = json.load(open(web_path / ".mapping.json"))
     print(mapping)
@@ -75,7 +77,7 @@ def test_build(tmp_path: Path, script_runner):
             "frontmatter",
             "frontmatter-preface",
         ],
-        f"{source_prefix}ch-first.ptx": ["ch-first"],
+        f"{source_prefix}ch-first with spaces.ptx": ["ch-first-without-spaces"],
         f"{source_prefix}sec-first-intro.ptx": ["sec-first-intro"],
         f"{source_prefix}sec-first-examples.ptx": ["sec-first-examples"],
         f"{source_prefix}ex-first.ptx": ["ex-first"],
@@ -91,23 +93,25 @@ def test_build(tmp_path: Path, script_runner):
         "build",
         "subset",
         "-x",
-        "ch-first",
-        cwd=tmp_path,
+        "ch-first-without-spaces",
+        cwd=project_path,
     ).success
-    assert (tmp_path / "output" / "subset").exists()
-    assert not (tmp_path / "output" / "subset" / "ch-empty.html").exists()
-    assert (tmp_path / "output" / "subset" / "ch-first.html").exists()
-    assert script_runner.run(PTX_CMD, "build", "print-latex", cwd=tmp_path).success
-    assert (tmp_path / "output" / "print-latex").exists()
+    assert (project_path / "output" / "subset").exists()
+    assert not (project_path / "output" / "subset" / "ch-empty.html").exists()
+    assert (
+        project_path / "output" / "subset" / "ch-first-without-spaces.html"
+    ).exists()
+    assert script_runner.run(PTX_CMD, "build", "print-latex", cwd=project_path).success
+    assert (project_path / "output" / "print-latex").exists()
     assert script_runner.run(
-        PTX_CMD, "-v", "debug", "build", "-g", cwd=tmp_path
+        PTX_CMD, "-v", "debug", "build", "-g", cwd=project_path
     ).success
-    assert (tmp_path / "generated-assets").exists()
-    os.removedirs(tmp_path / "generated-assets")
+    assert (project_path / "generated-assets").exists()
+    os.removedirs(project_path / "generated-assets")
     assert script_runner.run(
-        PTX_CMD, "-v", "debug", "build", "-g", "webwork", cwd=tmp_path
+        PTX_CMD, "-v", "debug", "build", "-g", "webwork", cwd=project_path
     ).success
-    assert (tmp_path / "generated-assets").exists()
+    assert (project_path / "generated-assets").exists()
 
 
 def test_init(tmp_path: Path, script_runner):


### PR DESCRIPTION
This fix handles spaces in pathname by URL-decoding the path to produce a pathname that matches the filesystem.

It also included a set of improved tests with:

- A space in the project path
- A space in a .ptx file
- An different XML ID than the filename.

 These tests fail under the old approach, but work with this approach.
