### PR TITLE
Revert "Alternative fix to handling spaces in path names"

### DIFF
--- a/pretext/codechat.py
+++ b/pretext/codechat.py
@@ -106,8 +106,6 @@ def map_path_to_xml_id(
             # On Windows, this produces ``path == "/C:/path/to/file.ptx"``. Remove the slash.
             if is_win:
                 path = path[1:]
-            # Decode the URL-encoded filename.
-            path = urllib.parse.unquote(path)
             # Use ``resolve()`` to standardize capitalization on Windows.
             stdpath = pathlib.Path(path).resolve()
             # Make this path relative to the project directory, to avoid writing potentially confidential information (username / local filesystem paths) to the mapping file, which might be published to the web.

--- a/templates/demo/source/ch-first.ptx
+++ b/templates/demo/source/ch-first.ptx
@@ -2,7 +2,7 @@
 <!-- Chapters are enclosed with <chapter> tags. Use xml:id to -->
 <!-- uniquely identify the chapter.  The @xmlns:xi attribute  -->
 <!-- is needed if you use xi:include in this file             -->
-<chapter xml:id="ch-first-without-spaces" xmlns:xi="http://www.w3.org/2001/XInclude">
+<chapter xml:id="ch-first" xmlns:xi="http://www.w3.org/2001/XInclude">
 
 <!-- Change title when you have one: -->
   <title>My First Chapter</title>

--- a/templates/demo/source/main.ptx
+++ b/templates/demo/source/main.ptx
@@ -27,7 +27,7 @@
     <!-- possible structure of the book.  Once you know what the   -->
     <!-- title of the chapter is, rename the file something based  -->
     <!-- on the title (ch-shorttitle.ptx) both here and on disk    -->
-    <xi:include href="./ch-first%20with%20spaces.ptx" />
+    <xi:include href="./ch-first.ptx" />
     <xi:include href="./ch-empty.ptx"/>
     <!-- Of course you will want to add more chapters as you proceed-->
 
@@ -36,7 +36,7 @@
     <!-- We recommend keeping this handy, and commenting it out    -->
     <!-- when you show off your own work.                          -->
     <xi:include href="./ch-features.ptx" />
-
+  
     <!-- This chapter includes several features that require pregeneration   -->
     <!-- of assets with `pretext generate` or similar. Some features require -->
     <!-- internet access; others require local installs not automatically    -->

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,15 +55,13 @@ def test_new(tmp_path: Path, script_runner):
 
 
 def test_build(tmp_path: Path, script_runner):
-    path_with_spaces = "test path with spaces"
-    project_path = tmp_path / path_with_spaces
     assert script_runner.run(
-        PTX_CMD, "-v", "debug", "new", "demo", "-d", path_with_spaces, cwd=tmp_path
+        PTX_CMD, "-v", "debug", "new", "demo", "-d", ".", cwd=tmp_path
     ).success
     assert script_runner.run(
-        PTX_CMD, "-v", "debug", "build", "web", cwd=project_path
+        PTX_CMD, "-v", "debug", "build", "web", cwd=tmp_path
     ).success
-    web_path = project_path / "output" / "web"
+    web_path = tmp_path / "output" / "web"
     assert web_path.exists()
     mapping = json.load(open(web_path / ".mapping.json"))
     print(mapping)
@@ -77,7 +75,7 @@ def test_build(tmp_path: Path, script_runner):
             "frontmatter",
             "frontmatter-preface",
         ],
-        f"{source_prefix}ch-first with spaces.ptx": ["ch-first-without-spaces"],
+        f"{source_prefix}ch-first.ptx": ["ch-first"],
         f"{source_prefix}sec-first-intro.ptx": ["sec-first-intro"],
         f"{source_prefix}sec-first-examples.ptx": ["sec-first-examples"],
         f"{source_prefix}ex-first.ptx": ["ex-first"],
@@ -93,25 +91,23 @@ def test_build(tmp_path: Path, script_runner):
         "build",
         "subset",
         "-x",
-        "ch-first-without-spaces",
-        cwd=project_path,
+        "ch-first",
+        cwd=tmp_path,
     ).success
-    assert (project_path / "output" / "subset").exists()
-    assert not (project_path / "output" / "subset" / "ch-empty.html").exists()
-    assert (
-        project_path / "output" / "subset" / "ch-first-without-spaces.html"
-    ).exists()
-    assert script_runner.run(PTX_CMD, "build", "print-latex", cwd=project_path).success
-    assert (project_path / "output" / "print-latex").exists()
+    assert (tmp_path / "output" / "subset").exists()
+    assert not (tmp_path / "output" / "subset" / "ch-empty.html").exists()
+    assert (tmp_path / "output" / "subset" / "ch-first.html").exists()
+    assert script_runner.run(PTX_CMD, "build", "print-latex", cwd=tmp_path).success
+    assert (tmp_path / "output" / "print-latex").exists()
     assert script_runner.run(
-        PTX_CMD, "-v", "debug", "build", "-g", cwd=project_path
+        PTX_CMD, "-v", "debug", "build", "-g", cwd=tmp_path
     ).success
-    assert (project_path / "generated-assets").exists()
-    os.removedirs(project_path / "generated-assets")
+    assert (tmp_path / "generated-assets").exists()
+    os.removedirs(tmp_path / "generated-assets")
     assert script_runner.run(
-        PTX_CMD, "-v", "debug", "build", "-g", "webwork", cwd=project_path
+        PTX_CMD, "-v", "debug", "build", "-g", "webwork", cwd=tmp_path
     ).success
-    assert (project_path / "generated-assets").exists()
+    assert (tmp_path / "generated-assets").exists()
 
 
 def test_init(tmp_path: Path, script_runner):


### PR DESCRIPTION
Reverts PreTeXtBook/pretext-cli#395

Actually, I spoke too soon.  I tried your fix and it doesn't work if there is a space in the path to the file.  For example, if the directory holding the project is `new project` then I get this error:

`critical: 'C:\\Users\\oscar.levin\\Documents\\dev\\pretext-cli\\new project\\source\\main.ptx' does not start with 'C:\\Users\\oscar.levin\\Documents\\dev\\pretext-cli\\new%20project'`

Thoughts?