### PR TITLE
reimplement interactive previews

### DIFF
--- a/pretext/__init__.py
+++ b/pretext/__init__.py
@@ -19,7 +19,7 @@ from single_version import get_version
 VERSION = get_version("pretext", Path(__file__).parent.parent)
 
 
-CORE_COMMIT = "a6d1b0c6c7825851b11bddddf88c22b4f90ef703"
+CORE_COMMIT = "12863f2d02678fceb1219b69caaba774a6e17a67"
 
 
 def activate():

--- a/pretext/generate.py
+++ b/pretext/generate.py
@@ -195,8 +195,8 @@ def asymptote(
 
 
 def interactive(ptxfile: Path, pub_file: Path, output: Path, params, xmlid_root):
-    log.warning("Interactive preview generation is temporarily unavailable.")
-    return
+    # First verify that playwright has dependencies installed:
+    utils.playwright_install()
     # We assume passed paths are absolute.
     # parse source so we can check for interactives.
     source_xml = ET.parse(ptxfile)

--- a/pretext/utils.py
+++ b/pretext/utils.py
@@ -447,6 +447,19 @@ def npm_install():
             log.critical(e)
             log.debug("", exc_info=True)
 
+def playwright_install():
+    '''
+    Run `playwright install` to ensure that its required browsers and tools are available to it.
+    '''
+    try:
+        subprocess.run("playwright install", shell=True)
+        log.debug("Installed dependencies to capture interactive previews")
+    except Exception as e:
+        log.critical(
+            "Unable to install required playwright packages.  Please see the documentation."
+        )
+        log.critical(e)
+        log.debug("", exc_info=True)
 
 def remove_path(path: Path):
     if path.is_file() or path.is_symlink():

--- a/pretext/utils.py
+++ b/pretext/utils.py
@@ -447,10 +447,11 @@ def npm_install():
             log.critical(e)
             log.debug("", exc_info=True)
 
+
 def playwright_install():
-    '''
+    """
     Run `playwright install` to ensure that its required browsers and tools are available to it.
-    '''
+    """
     try:
         subprocess.run("playwright install", shell=True)
         log.debug("Installed dependencies to capture interactive previews")
@@ -460,6 +461,7 @@ def playwright_install():
         )
         log.critical(e)
         log.debug("", exc_info=True)
+
 
 def remove_path(path: Path):
     if path.is_file() or path.is_symlink():

--- a/templates/demo/assets/jsxgraph/infinity.js
+++ b/templates/demo/assets/jsxgraph/infinity.js
@@ -1,0 +1,55 @@
+/* http://jsxgraph.uni-bayreuth.de/showcase/infinity.html */
+/* Accessed January 2017                                  */
+
+JXG.Options.renderer = 'canvas';
+var board = JXG.JSXGraph.initBoard('jsxgraph-infinity', {
+        boundingbox: [-9, 8, 9, -10],
+        keepaspectreatio: true,
+        axis: false,
+        grid: false,
+        shownavigation: false
+    });
+
+// construction
+board.suspendUpdate();
+var S = board.create('slider', [[-5,-6],[5,-6],[0,0.85,1]], {
+    name:'Whirl'
+});
+var hue = board.create('slider', [[-5,-7],[5,-7],[0,20.5,36]], {
+    name:'Colors'
+});
+
+var points = new Array();
+points[0] = board.create('point',[5, 5], {name:' '});
+points[1] = board.create('point',[-5, 5], {name:' '});
+points[2] = board.create('point',[-5, -5], {name:' '});
+points[3] = board.create('point',[5, -5], {name:' '});
+
+function quadrangle(pt, n) {
+    var col;
+    var arr = new Array();
+    for(var i = 0; i < 4; i++) {
+        arr[i] = board.create('point',
+            [function(t) {
+                return function () {var x = pt[t].X();
+                        var x1 = pt[(t+1)%4].X();
+                        var s = S.Value();
+                        return x+(x1-x)*s;
+                 }}(i),
+            function(t) {
+                return function () {var y = pt[t].Y();
+                        var y1 = pt[(t+1)%4].Y();
+                        var s = S.Value();
+                        return y+(y1-y)*s;
+                 }}(i)
+            ],
+        {size:1, name: "", withLabel: false, visible: false});
+    }
+    col =  function(){return JXG.hsv2rgb(hue.Value()*n,0.7,0.9);};
+    board.create('polygon',pt, {fillColor:col});
+    if(n>0)
+        quadrangle(arr, --n);
+}
+quadrangle(points,30);
+
+board.unsuspendUpdate();

--- a/templates/demo/source/ch-generate.ptx
+++ b/templates/demo/source/ch-generate.ptx
@@ -48,8 +48,25 @@
     <title>YouTube Example</title>
     <video youtube="dQw4w9WgXcQ"/>
   </section>
+  <section>
+    <title>Interactive Example</title>
+    <!-- From the sample article -->
+    <figure>
+      <caption>Infinity, from the JSXGraph Showcase</caption>
+
+      <interactive xml:id="interactive-infinity" platform="jsxgraph" width="60%"
+        source="jsxgraph/infinity.js">
+        <slate xml:id="jsxgraph-infinity" surface="jsxboard" />
+        <instructions>
+          <p>Drag the sliders to change the pattern, and drag any of the four red corners to change
+            the overall shape.</p>
+        </instructions>
+      </interactive>
+    </figure>
+  </section>
   <section xml:id="codelens">
-    <title>Codelens Example</title>
+    <title>Codelens
+      Example</title>
     <listing xml:id="sieve-python">
       <caption>Finding primes</caption>
       <program xml:id="sieve-codelens-python" interactive="codelens" language="python">

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -156,7 +156,7 @@ def test_generate_interactive(tmp_path: Path, script_runner):
         int_path
         / "generated-assets"
         / "preview"
-        / "calcplot3d-probability-wavefunction.png"
+        / "interactive-infinity-preview.png"
     )
     assert preview_file.exists()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -153,10 +153,7 @@ def test_generate_interactive(tmp_path: Path, script_runner):
     shutil.copytree(EXAMPLES_DIR / "projects" / "interactive", int_path)
     assert script_runner.run(PTX_CMD, "-v", "debug", "generate", cwd=int_path).success
     preview_file = (
-        int_path
-        / "generated-assets"
-        / "preview"
-        / "interactive-infinity-preview.png"
+        int_path / "generated-assets" / "preview" / "interactive-infinity-preview.png"
     )
     assert preview_file.exists()
 


### PR DESCRIPTION
Once the second pull request (https://github.com/PreTeXtBook/pretext/pull/1896) has been merged, we will implement the test here, and then should be all ready to go on the CLI.  Note that we now run `playwright install` every time interactives are generated, but this only does anything the first time it is run.