### PR TITLE
remove dummy `pretextbook` setup.py

### DIFF
--- a/pretextbook/setup.py
+++ b/pretextbook/setup.py
@@ -1,6 +1,0 @@
-# This package was previously released as pretextbook on PyPI for versions pre-1.0.
-# To capture projects on GitHub using such versions we fake a setup.py here.
-
-raise Exception("File provided to satisfy GitHub only.")
-
-setup(name="pretextbook")  # noqa: F821


### PR DESCRIPTION
This hack seems to no longer be working to track dependencies of the old `pretextbook` PyPI package anyway, so I propose removing this directory and dummy `setup.py` file.