### PR TITLE
add pretext/pretext script runner

### DIFF
--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -14,6 +14,7 @@ import platform
 from pathlib import Path
 import typing as t
 import atexit
+import subprocess
 from .config import xml_overlay
 
 from . import utils, templates, core, VERSION, CORE_COMMIT
@@ -143,6 +144,21 @@ def support():
                 )
     else:
         log.info("No project.ptx found.")
+
+
+# pretext support
+@main.command(
+    name="core",
+    short_help="Alias for the legacy pretext/pretext core script.",
+    context_settings={"help_option_names":[],"ignore_unknown_options":True},
+)
+@click.argument('args', nargs=-1)
+def core_command(args):
+    """
+    Aliases the core pretext script.
+    """
+    PY_CMD = sys.executable
+    subprocess.run([PY_CMD, core.resources.path("pretext","pretext")]+list(args))
 
 
 # pretext new

--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -146,7 +146,7 @@ def support():
         log.info("No project.ptx found.")
 
 
-# pretext support
+# pretext devscript
 @main.command(
     short_help="Alias for the developer pretext/pretext script.",
     context_settings={"help_option_names": [], "ignore_unknown_options": True},

--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -148,17 +148,16 @@ def support():
 
 # pretext support
 @main.command(
-    name="core",
-    short_help="Alias for the legacy pretext/pretext core script.",
-    context_settings={"help_option_names":[],"ignore_unknown_options":True},
+    short_help="Alias for the developer pretext/pretext script.",
+    context_settings={"help_option_names": [], "ignore_unknown_options": True},
 )
-@click.argument('args', nargs=-1)
-def core_command(args):
+@click.argument("args", nargs=-1)
+def devscript(args):
     """
     Aliases the core pretext script.
     """
     PY_CMD = sys.executable
-    subprocess.run([PY_CMD, core.resources.path("pretext","pretext")]+list(args))
+    subprocess.run([PY_CMD, core.resources.path("pretext", "pretext")] + list(args))
 
 
 # pretext new

--- a/scripts/fetch_core.py
+++ b/scripts/fetch_core.py
@@ -21,7 +21,7 @@ def main():
         archive.extractall(tmpdirname)
         print("Creating zip of static folders")
         # Copy required folders to a single folder to be zipped:
-        for subdir in ["xsl", "schema", "script", "css"]:
+        for subdir in ["xsl", "schema", "script", "css", "pretext"]:
             shutil.copytree(
                 Path(tmpdirname) / f"pretext-{CORE_COMMIT}" / subdir,
                 Path(tmpdirname) / "static" / subdir,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,6 +50,15 @@ def test_new(tmp_path: Path, script_runner):
     assert (tmp_path / "new-pretext-project" / "project.ptx").exists()
 
 
+def test_core(script_runner):
+    """
+    Test that `pretext core -h` aliases `python /path/to/.ptx/pretext/pretext -h`.
+    """
+    result = script_runner.run(PTX_CMD, "core", "-h")
+    assert result.success
+    assert "PreTeXt utility script" in result.stdout
+
+
 def test_build(tmp_path: Path, script_runner):
     path_with_spaces = "test path with spaces"
     project_path = tmp_path / path_with_spaces

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,11 +50,11 @@ def test_new(tmp_path: Path, script_runner):
     assert (tmp_path / "new-pretext-project" / "project.ptx").exists()
 
 
-def test_core(script_runner):
+def test_devscript(script_runner):
     """
-    Test that `pretext core -h` aliases `python /path/to/.ptx/pretext/pretext -h`.
+    Test that `pretext devscript -h` aliases `python /path/to/.ptx/pretext/pretext -h`.
     """
-    result = script_runner.run(PTX_CMD, "core", "-h")
+    result = script_runner.run(PTX_CMD, "devscript", "-h")
     assert result.success
     assert "PreTeXt utility script" in result.stdout
 


### PR DESCRIPTION
Usage: `pretext devscript [OPTS/ARGS]` aliases  `./path/to/pretext/pretext [OPTS/ARGS]`.

One deficiency I'm aware of: it uses the default `pretext.cfg` and not `project.ptx`'s executables. However, I think since we're now installing `pretext.cfg` into the user's `~./ptx` folder, maybe we should move executables info there anyway. Thoughts @oscarlevin?