### PR TITLE
Add `install-deps` playwright command

### DIFF
--- a/pretext/utils.py
+++ b/pretext/utils.py
@@ -451,6 +451,8 @@ def playwright_install():
     Run `playwright install` to ensure that its required browsers and tools are available to it.
     """
     try:
+        log.info("Attempting to install/update required playwright packages.")
+        subprocess.run("playwright install-deps", shell=True)
         subprocess.run("playwright install", shell=True)
         log.debug("Installed dependencies to capture interactive previews")
     except Exception as e:


### PR DESCRIPTION
This should fix the issue of playwright not working on some machines because some system managed deps are missing.  Might prompt the user for a password.

Closes #436