### PR TITLE
add logging to __inti__.py

### DIFF
--- a/pretext/__init__.py
+++ b/pretext/__init__.py
@@ -13,8 +13,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import logging
 from pathlib import Path
 from single_version import get_version
+
+log = logging.getLogger("ptxlogger")
 
 VERSION = get_version("pretext", Path(__file__).parent.parent)
 


### PR DESCRIPTION
This should allow a script that uses pretext as a module to recieve the output of log.*

We are not doing any configuration of the logger in this situation; all that is done inside `cli.py`, which is probably correct.  We might want to consider changing the name of the logger to `__name__`, and setting some basic configuration at the __init__ stage too.