### PR TITLE
update devcontainer to work with codechat

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,71 @@
+{
+  "name": "PreTeXt-Codespaces",
+
+  // This Docker image includes some LaTeX support, but is still not to large.  Note that if you keep your codespace running, it will use up your GitHub free storage quota.  Additional options are listed below.
+  "image": "oscarlevin/pretext:small",
+  // If you need to generate more complicated assets (such as sageplots) or use additional fonts when building to PDF, comment out the above line and uncomment the following line.
+  // "image": "oscarlevin/pretext:full",
+  // If you only intend to build for web and don't have any latex-image generated assets, you can use a smaller image:
+  // "image": "oscarlevin/pretext:lite",
+
+  // Add gh cli as a feature (to support chodechat)
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+
+  // Port forwarding
+  // ---------------
+  // This is needed by the CodeChat Server.
+  "forwardPorts": [
+    // The port used for a Thrift connection between the VSCode CodeChat
+    // extension and the CodeChat Server.
+    27376,
+    // The port used for an HTTP connection from the CodeChat Client to
+    // the CodeChat Server.
+    27377,
+    // The port used by a websocket connection between the CodeChat
+    // Server and the CodeChat Client.
+    27378
+  ],
+  // See the [docs](https://containers.dev/implementors/json_reference/#port-attributes).
+  "portsAttributes": {
+    "27376": {
+      "label": "VSCode extension <-> CodeChat Server",
+      "requireLocalPort": true
+    },
+    "27377": {
+      "label": "CodeChat Client",
+      "requireLocalPort": true
+    },
+    "27378": {
+      "label": "CodeChat Client<->Server websocket",
+      "requireLocalPort": true
+      // This port needs to be public; however, there's no way to specify port visibility here. See `server.py` in the CodeChat Server for details.
+    }
+  },
+
+  // Configure tool-specific properties.
+  "customizations": {
+    "codespaces": {
+      "openFiles": ["source/main.ptx"]
+    },
+    "vscode": {
+      "settings": {
+        "editor.quickSuggestions": {
+          "other": "off"
+        },
+        "editor.snippetSuggestions": "top",
+        "xml.validation.enabled": false,
+        "CodeChat.CodeChatServer.Command": "CodeChat_Server"
+      },
+      "extensions": [
+        "ms-vscode.live-server",
+        "oscarlevin.pretext-tools",
+        "CodeChat.codechat"
+      ]
+    }
+  }
+
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
+}

--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -271,7 +271,7 @@ def init(refresh: bool) -> None:
         "project.ptx": "project.ptx",
         "publication.ptx": "publication/publication.ptx",
         ".gitignore": ".gitignore",
-        "devcontainer.json": ".devcontainer.json",
+        ".devcontainer.json": ".devcontainer.json",
     }
     for resource in resource_to_dest:
         with templates.resource_path(resource) as resource_path:

--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -271,7 +271,7 @@ def init(refresh: bool) -> None:
         "project.ptx": "project.ptx",
         "publication.ptx": "publication/publication.ptx",
         ".gitignore": ".gitignore",
-        "devcontainer.json": ".devcontainer/devcontainer.json",
+        "devcontainer.json": ".devcontainer.json",
     }
     for resource in resource_to_dest:
         with templates.resource_path(resource) as resource_path:

--- a/scripts/zip_templates.py
+++ b/scripts/zip_templates.py
@@ -30,12 +30,9 @@ def main() -> None:
                             Path("templates") / template_file,
                             copied_template_file,
                         )
-                dc_dir_path = temporary_path / ".devcontainer"
-                if not dc_dir_path.exists():
-                    dc_dir_path.mkdir()
                 shutil.copyfile(
-                    Path("templates") / "devcontainer.json",
-                    dc_dir_path / "devcontainer.json",
+                    Path("templates") / ".devcontainer.json",
+                    ".devcontainer.json",
                 )
                 template_zip_basename = template_path.name
                 shutil.make_archive(
@@ -47,7 +44,7 @@ def main() -> None:
         "project.ptx",
         "publication.ptx",
         ".gitignore",
-        "devcontainer.json",
+        ".devcontainer.json",
     ]:
         shutil.copyfile(Path("templates") / f, static_template_path / f)
 

--- a/templates/.devcontainer.json
+++ b/templates/.devcontainer.json
@@ -13,34 +13,41 @@
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
 
-  // The following was the previous version of this file, which used the Codespaces base image.  It is still available for reference, but is not recommended.
-  // "image": "mcr.microsoft.com/devcontainers/python:3",
-  // "features": {
-  //   "ghcr.io/devcontainers/features/node:1": {},
-  //   "ghcr.io/rocker-org/devcontainer-features/pandoc:1": {}
-  // },
-  // "forwardPorts": [
-  // 	27377,
-  // 	27378
-  // ],
-  // "portsAttributes": {
-  // 	"27378": {
-  // 		"label": "CodeChat",
-  // 		"onAutoForward": "openPreview",
-  // 		"requireLocalPort": true,
-  // 		"elevateIfNeeded": true,
-  // 		"protocol": "https"
-  // 	}
-  // },
-  // "onCreateCommand": "pip install pretext",
-  // // Use 'postCreateCommand' to run commands after the container is created.
+  // Port forwarding
+  // ---------------
+  // This is needed by the CodeChat Server.
+  "forwardPorts": [
+    // The port used for a Thrift connection between the VSCode CodeChat
+    // extension and the CodeChat Server.
+    27376,
+    // The port used for an HTTP connection from the CodeChat Client to
+    // the CodeChat Server.
+    27377,
+    // The port used by a websocket connection between the CodeChat
+    // Server and the CodeChat Client.
+    27378
+  ],
+  // See the [docs](https://containers.dev/implementors/json_reference/#port-attributes).
+  "portsAttributes": {
+    "27376": {
+      "label": "VSCode extension <-> CodeChat Server",
+      "requireLocalPort": true
+    },
+    "27377": {
+      "label": "CodeChat Client",
+      "requireLocalPort": true
+    },
+    "27378": {
+      "label": "CodeChat Client<->Server websocket",
+      "requireLocalPort": true
+      // This port needs to be public; however, there's no way to specify port visibility here. See `server.py` in the CodeChat Server for details.
+    }
+  },
 
   // Configure tool-specific properties.
   "customizations": {
     "codespaces": {
-      "openFiles": [
-        "source/main.ptx"
-      ]
+      "openFiles": ["source/main.ptx"]
     },
     "vscode": {
       "settings": {
@@ -51,7 +58,11 @@
         "xml.validation.enabled": false,
         "CodeChat.CodeChatServer.Command": "CodeChat_Server"
       },
-      "extensions": ["ms-vscode.live-server", "oscarlevin.pretext-tools", "CodeChat.codechat"]
+      "extensions": [
+        "ms-vscode.live-server",
+        "oscarlevin.pretext-tools",
+        "CodeChat.codechat"
+      ]
     }
   }
 


### PR DESCRIPTION
This should have the fixes for the new codechat configuration so that when pretext-codespace gets initialized with a `pretext new` it will be set up correctly.