### PR TITLE
fix zip_templates 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -35,6 +35,7 @@
 				"oscarlevin.pretext-tools",
 				"ms-python.python",
 				"ms-python.flake8",
+				"ms-python.black-formatter",
 				"streetsidesoftware.code-spell-checker"
 			]
 		}

--- a/scripts/zip_templates.py
+++ b/scripts/zip_templates.py
@@ -30,10 +30,6 @@ def main() -> None:
                             Path("templates") / template_file,
                             copied_template_file,
                         )
-                shutil.copyfile(
-                    Path("templates") / ".devcontainer.json",
-                    ".devcontainer.json",
-                )
                 template_zip_basename = template_path.name
                 shutil.make_archive(
                     str(static_template_path / template_zip_basename),


### PR DESCRIPTION
the zip_templets script was adding the duplicate .devcontainer in the root of this repo.  That's fixed.  Also added black-formatter extension to the true .devcontainer.