### PR TITLE
bubble up warning if a user isn't compatible with upcoming v2

### DIFF
--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -80,6 +80,9 @@ def main(ctx: click.Context, targets: bool) -> None:
     if (pp := utils.project_path()) is not None:
         try:
             ProjectRefactor.parse(pp)
+            log.info(
+                "------------------------------------\n Good news: \n Your project.ptx file is ready for\n the 2.0.0 release of PreTeXt-CLI.\n------------------------------------\n"
+            )
         except Exception as e:
             log.warning(
                 "Your project.ptx or publication file may not be compatible with the "
@@ -161,8 +164,22 @@ def support() -> None:
         log.info("------------------------")
         log.info(utils.project_xml_string())
         log.info("------------------------")
+        try:
+            ProjectRefactor.parse()
+            log.info(
+                "Your project.ptx file will be compatible with the upcoming 2.0.0 release of PreTeXt-CLI."
+            )
+        except Exception as e:
+            log.warning(
+                "Your project.ptx or publication file may not be compatible with the "
+                + "upcoming 2.0.0 release of PreTeXt-CLI."
+            )
+            log.info("")
+            log.warning(f"Exception info: {e}")
+            log.info("")
         project = Project()
         project.init_ptxcore()
+        log.info("------------------------")
         for exec_name in project.executables():
             if utils.check_executable(exec_name) is None:
                 log.warning(

--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -26,6 +26,7 @@ from . import (
     CORE_COMMIT,
 )
 from .project import Project
+from .project.refactor import Project as ProjectRefactor
 
 
 log = logging.getLogger("ptxlogger")
@@ -77,6 +78,24 @@ def main(ctx: click.Context, targets: bool) -> None:
     `pretext build --help`.
     """
     if (pp := utils.project_path()) is not None:
+        try:
+            ProjectRefactor.parse(pp)
+        except Exception as e:
+            log.warning(
+                "Your project.ptx or publication file may not be compatible with the "
+                + "upcoming 2.0.0 release of PreTeXt-CLI."
+            )
+            log.warning(
+                "For more information or to help us fix a possible bug, please visit"
+            )
+            log.warning("    https://groups.google.com/g/pretext-support/c/bwf51qOoT9c")
+            log.warning(
+                "and share the result of running `pretext support` on your machine with us."
+            )
+            log.info("")
+            log.warning(f"Exception info: {e}")
+            log.info("")
+            log.warning("Continuing with current version...")
         if targets:
             Project().print_target_names()
             return


### PR DESCRIPTION
I believe this is ready for the field in a 1.7.3 release.