### PR TITLE
Change: Instead of a Runestone format, provide a platform="runestone" attribute

### DIFF
--- a/pretext/generate.py
+++ b/pretext/generate.py
@@ -26,7 +26,6 @@ def latex_image(
         "pdf": [],
         "latex": [],
         "html": ["svg"],
-        "runestone": ["svg"],
         "epub": ["svg"],
         "kindle": ["png"],
     }
@@ -79,7 +78,6 @@ def sageplot(
         "pdf": ["pdf", "png"],
         "latex": ["pdf", "png"],
         "html": ["html", "svg"],
-        "runestone": ["html", "svg"],
         "epub": ["svg"],
         "kindle": ["png"],
     }
@@ -132,7 +130,6 @@ def asymptote(
         "pdf": ["pdf"],
         "latex": ["pdf"],
         "html": ["html"],
-        "runestone": ["html"],
         "epub": ["svg"],
         "kindle": ["png"],
     }
@@ -213,7 +210,7 @@ def interactive(
                 )
             except Exception as e:
                 log.error(
-                    "Failed to generate interactive element previews.  You might need to run `playwright install-deps` to get this to work. Check debug log for info."
+                    "Failed to generate interactive element previews. Check debug log for info."
                 )
                 log.debug(e)
                 log.debug("Exception info:\n##################\n", exc_info=True)

--- a/tests/examples/projects/project_refactor/simple/project.ptx
+++ b/tests/examples/projects/project_refactor/simple/project.ptx
@@ -2,7 +2,7 @@
 <project ptx-version="2">
   <targets>
     <target name="web" format="html"/>
-    <target name="rs" format="runestone"/>
+    <target name="rs" format="html" platform="runestone"/>
     <target name="print" format="pdf"/>
   </targets>
 </project>

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -103,14 +103,20 @@ def test_manifest_simple(tmp_path: Path) -> None:
         project = pr.Project.parse()
         assert len(project.targets) == 3
 
-        assert project.get_target("web").format == "html"
-        assert project.get_target("web").site == Path("site")
+        t_web = project.get_target("web")
+        assert t_web.format == "html"
+        assert t_web.platform == "web"
+        assert t_web.site == Path("site")
 
-        assert project.get_target("print").format == "pdf"
-        assert project.get_target("print").site == Path("site")
+        t_print = project.get_target("print")
+        assert t_print.format == "pdf"
+        assert t_print.platform is None
+        assert t_print.site == Path("site")
 
-        assert project.get_target("rs").format == "runestone"
-        assert project.get_target("rs").output_dir_abspath().resolve().relative_to(
+        t_rune = project.get_target("rs")
+        assert t_rune.format == "html"
+        assert t_rune.platform == "runestone"
+        assert t_rune.output_dir_abspath().resolve().relative_to(
             project.abspath()
         ) == Path("published/runestone-document-id")
 
@@ -346,9 +352,16 @@ def test_validation() -> None:
         project.new_target(name="test", format="html", output_filename="not-allowed")
     with pytest.raises(pydantic.ValidationError):
         project.new_target(
-            name="test", format="runestone", output_filename="not-allowed"
+            name="test",
+            format="html",
+            platform="runestone",
+            output_filename="not-allowed",
         )
     with pytest.raises(pydantic.ValidationError):
-        project.new_target(name="test", format="runestone", output_dir="not-allowed")
+        project.new_target(
+            name="test", format="html", platform="runestone", output_dir="not-allowed"
+        )
     with pytest.raises(pydantic.ValidationError):
         project.new_target(name="test", format="pdf", compression="zip")
+    with pytest.raises(pydantic.ValidationError):
+        project.new_target(name="test", format="pdf", platform="runestone")


### PR DESCRIPTION
Based on yesterday's discussion, this replaces the `runestone` target with a `platform="web/runestone"` attribute, which can only be applied to a `html` target.