### PR TITLE
Remove pydantic forbid extra elements in legacy

### DIFF
--- a/pretext/project/xml.py
+++ b/pretext/project/xml.py
@@ -45,13 +45,13 @@ class LatexEngine(str, Enum):
 
 
 class LegacyStringParam(pxml.BaseXmlModel):
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict()
     key: str = pxml.attr()
     value: str = pxml.attr()
 
 
 class LegacyTarget(pxml.BaseXmlModel, tag="target", search_mode=SearchMode.UNORDERED):
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict()
     name: str = pxml.attr()
     latex_engine: t.Optional[LatexEngine] = pxml.attr(name="pdf-method", default=None)
     format: LegacyFormat = pxml.element()
@@ -70,7 +70,7 @@ class LegacyTarget(pxml.BaseXmlModel, tag="target", search_mode=SearchMode.UNORD
 class LegacyExecutables(
     pxml.BaseXmlModel, tag="executables", search_mode=SearchMode.UNORDERED
 ):
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict()
     latex: str = pxml.element()
     pdflatex: str = pxml.element()
     xelatex: str = pxml.element()
@@ -84,6 +84,6 @@ class LegacyExecutables(
 
 
 class LegacyProject(pxml.BaseXmlModel, tag="project", search_mode=SearchMode.UNORDERED):
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict()
     targets: t.List[LegacyTarget] = pxml.wrapped("targets", pxml.element(tag="target"))
     executables: LegacyExecutables = pxml.element()

--- a/tests/examples/projects/project_refactor/legacy_extra/project.ptx
+++ b/tests/examples/projects/project_refactor/legacy_extra/project.ptx
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This file provides the overall configuration for your PreTeXt project. To edit the content of your document, open `source/main.ptx` (default location). -->
+<project>
+    <!-- Note that this entry is last, though it's listed first in the schema, to check that it's still found. -->
+    <executables>
+        <pdflatex>pdflatex</pdflatex>
+        <xelatex>xelatex</xelatex>
+        <pdfsvg>pdf2svg</pdfsvg>
+        <asy>asy</asy>
+        <sage>sage</sage>
+        <pdfpng>convert</pdfpng>
+        <pdfeps>pdftops</pdfeps>
+        <node>node</node>
+        <liblouis>foobar</liblouis>
+        <!-- Add an "executable" that is not expected to test that this doesn't throw error -->
+        <foobar>foobar.exe</foobar>
+        <!-- Note that this entry is last, though it's listed first in the schema, to check that it's still found. -->
+        <latex>latex1</latex>
+    </executables>
+    <targets>
+        <target name="html">
+            <source>source/main.ptx</source>
+            <publication>publication/publication.ptx</publication>
+            <output-dir>output/html</output-dir>
+            <stringparam
+                key="one"
+                value="uno"
+            />
+            <stringparam
+                key="two"
+                value="dos"
+            />
+            <!-- Note that this entry is last, though it's listed first in the schema, to check that it's still found. -->
+            <format>html</format>
+        </target>
+        <target name="latex">
+            <format>latex</format>
+            <source>source/main.ptx</source>
+            <publication>publication/publication.ptx</publication>
+            <output-dir>output/latex</output-dir>
+            <!-- Unexpected element should not result in error for legacy projects -->
+            <extra-element>foo</extra-element>
+        </target>
+        <target
+            name="pdf"
+            pdf-method="pdflatex"
+        >
+            <format>pdf</format>
+            <source>source/main.ptx</source>
+            <publication>publication/publication.ptx</publication>
+            <output-dir>output/pdf</output-dir>
+        </target>
+    </targets>
+    <!-- This isn't part of the schema, but shouldn't throw error right now. -->
+    <sites>
+        <target name="html">
+            <dir>fake</dir>
+        </target>
+    </sites>
+</project>

--- a/tests/examples/projects/project_refactor/legacy_extra/publication/publication.ptx
+++ b/tests/examples/projects/project_refactor/legacy_extra/publication/publication.ptx
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<publication>
+    <!-- directories are relative to the main source PreTeXt file -->
+    <source>
+        <directories external="../assets" generated="../generated-assets"/>
+    </source>
+</publication>

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -256,6 +256,46 @@ def test_manifest_legacy() -> None:
         assert project._executables.latex == "latex1"
 
 
+# Repeat the above test with a manifest that has extra, unknown elements. This should still work, but the extra elements should be ignored.
+def test_manifest_legacy_wrong() -> None:
+    prj_path = EXAMPLES_DIR / "projects" / "project_refactor" / "legacy_extra"
+    with utils.working_directory(prj_path):
+        project = pr.Project.parse()
+        assert len(project.targets) == 3
+
+        assert project._executables.xelatex == "xelatex"
+        assert project._executables.liblouis == "foobar"
+
+        t_html = project.get_target("html")
+        assert t_html is not None
+        assert t_html.format == "html"
+        assert t_html.source_abspath() == project.abspath() / Path("source", "main.ptx")
+        assert t_html.publication_abspath() == project.abspath() / Path(
+            "publication", "publication.ptx"
+        )
+        assert t_html.output_dir_abspath() == project.abspath() / Path("output", "html")
+        assert t_html.latex_engine == "xelatex"
+        assert t_html.stringparams == {"one": "uno", "two": "dos"}
+
+        t_latex = project.get_target("latex")
+        assert t_latex.format == "latex"
+        assert t_latex.source == Path("source", "main.ptx")
+        assert t_latex.publication == Path("publication", "publication.ptx")
+        assert t_latex.output_dir == Path("output", "latex")
+        assert t_latex.latex_engine == "xelatex"
+
+        t_pdf = project.get_target("pdf")
+        assert t_pdf.format == "pdf"
+        assert t_pdf.source == Path("source", "main.ptx")
+        assert t_pdf.publication == Path("publication", "publication.ptx")
+        assert t_pdf.output_dir == Path("output", "pdf")
+        assert t_pdf.latex_engine == "pdflatex"
+
+        assert not project.has_target("foo")
+
+        assert project._executables.latex == "latex1"
+
+
 def test_demo_html_build(tmp_path: Path) -> None:
     path_with_spaces = "test path with spaces"
     project_path = tmp_path / path_with_spaces


### PR DESCRIPTION
The recent upgrade to pydantic-xml (to 2.2.0) adds the feature to forbid extra elements not specified in the model.  This is a great feature for v2, but we have been promising users who had previously had extra elements that their projects would still work.

So I have removed this requirement.  Users who have extra non-read elements should upgrade to v2 manifests soon anyway, and if a legacy manifest is wrong and it is causing issues because of a misspelled element name, then we can deal with that help request just as easily as dealing with the help request when their project no longer compiles.