### PR TITLE
Avoid generating unneeded assets

### DIFF
--- a/pretext/constants.py
+++ b/pretext/constants.py
@@ -19,7 +19,7 @@ ASSETS_BY_FORMAT = {
         "youtube",
         "codelense",
         "datafile",
-        "interactive"
+        "interactive",
     ],
     "latex": [
         "webwork",
@@ -28,7 +28,7 @@ ASSETS_BY_FORMAT = {
         "youtube",
         "codelense",
         "datafile",
-        "interactive"
+        "interactive",
     ],
     "epub": [
         "webwork",
@@ -38,7 +38,7 @@ ASSETS_BY_FORMAT = {
         "youtube",
         "codelense",
         "datafile",
-        "interactive"
+        "interactive",
     ],
     "kindle": [
         "webwork",
@@ -48,7 +48,7 @@ ASSETS_BY_FORMAT = {
         "youtube",
         "codelense",
         "datafile",
-        "interactive"
+        "interactive",
     ],
     "braille": [
         "webwork",
@@ -58,7 +58,7 @@ ASSETS_BY_FORMAT = {
         "youtube",
         "codelense",
         "datafile",
-        "interactive"
+        "interactive",
     ],
     "webwork": [
         "webwork",
@@ -71,7 +71,7 @@ ASSETS_BY_FORMAT = {
         "youtube",
         "codelense",
         "datafile",
-        "interactive"
+        "interactive",
     ],
 }
 

--- a/pretext/constants.py
+++ b/pretext/constants.py
@@ -2,6 +2,8 @@ import typing as t
 
 NEW_TEMPLATES = ["book", "article", "demo", "hello", "slideshow"]
 
+FORMATS = ["html", "pdf", "latex", "epub", "kindle", "braille", "webwork", "custom"]
+
 # Give list of assets that each build format requires.
 ASSETS_BY_FORMAT = {
     "html": [

--- a/pretext/constants.py
+++ b/pretext/constants.py
@@ -2,17 +2,78 @@ import typing as t
 
 NEW_TEMPLATES = ["book", "article", "demo", "hello", "slideshow"]
 
-BUILD_FORMATS = [
-    "html",
-    "pdf",
-    "latex",
-    "epub",
-    "kindle",  # TODO: mode of epub rather than separate format?
-    "braille",
-    "html-zip",  # TODO: deprecate
-    "webwork-sets",  # TODO: just "webwork"
-    "webwork-sets-zipped",  # TODO: deprecate
-]
+# Give list of assets that each build format requires.
+ASSETS_BY_FORMAT = {
+    "html": [
+        "webwork",
+        "latex-image",
+        "sageplot",
+        "asymptote",
+        "codelense",
+        "datafile",
+    ],
+    "pdf": [
+        "webwork",
+        "sageplot",
+        "asymptote",
+        "youtube",
+        "codelense",
+        "datafile",
+        "interactive"
+    ],
+    "latex": [
+        "webwork",
+        "sageplot",
+        "asymptote",
+        "youtube",
+        "codelense",
+        "datafile",
+        "interactive"
+    ],
+    "epub": [
+        "webwork",
+        "latex-image",
+        "sageplot",
+        "asymptote",
+        "youtube",
+        "codelense",
+        "datafile",
+        "interactive"
+    ],
+    "kindle": [
+        "webwork",
+        "latex-image",
+        "sageplot",
+        "asymptote",
+        "youtube",
+        "codelense",
+        "datafile",
+        "interactive"
+    ],
+    "braille": [
+        "webwork",
+        "latex-image",
+        "sageplot",
+        "asymptote",
+        "youtube",
+        "codelense",
+        "datafile",
+        "interactive"
+    ],
+    "webwork": [
+        "webwork",
+    ],
+    "custom": [
+        "webwork",
+        "latex-image",
+        "sageplot",
+        "asymptote",
+        "youtube",
+        "codelense",
+        "datafile",
+        "interactive"
+    ],
+}
 
 ASSET_TO_XPATH = {
     "webwork": ".//webwork[*|@*]",

--- a/pretext/project/__init__.py
+++ b/pretext/project/__init__.py
@@ -639,8 +639,14 @@ class Target(pxml.BaseXmlModel, tag="target", search_mode=SearchMode.UNORDERED):
         if specified_asset_types is None or "ALL" in specified_asset_types:
             specified_asset_types = list(constants.ASSET_TO_XPATH.keys())
         log.debug(f"Assets generation requested for: {specified_asset_types}.")
-        specified_asset_types = [asset for asset in specified_asset_types if asset in constants.ASSETS_BY_FORMAT[self.format]]
-        log.debug(f"Based on format {self.format}, assets to be generated are: {specified_asset_types}.")
+        specified_asset_types = [
+            asset
+            for asset in specified_asset_types
+            if asset in constants.ASSETS_BY_FORMAT[self.format]
+        ]
+        log.debug(
+            f"Based on format {self.format}, assets to be generated are: {specified_asset_types}."
+        )
         # We always build the asset hash table, even if only_changed=False: this tells us which assets need to be built, and how to update the saved asset hash table.
         source_asset_table = self.generate_asset_table()
         saved_asset_table = utils.clean_asset_table(

--- a/pretext/project/__init__.py
+++ b/pretext/project/__init__.py
@@ -639,6 +639,8 @@ class Target(pxml.BaseXmlModel, tag="target", search_mode=SearchMode.UNORDERED):
         if specified_asset_types is None or "ALL" in specified_asset_types:
             specified_asset_types = list(constants.ASSET_TO_XPATH.keys())
         log.debug(f"Assets generation requested for: {specified_asset_types}.")
+        specified_asset_types = [asset for asset in specified_asset_types if asset in constants.ASSETS_BY_FORMAT[self.format]]
+        log.debug(f"Based on format {self.format}, assets to be generated are: {specified_asset_types}.")
         # We always build the asset hash table, even if only_changed=False: this tells us which assets need to be built, and how to update the saved asset hash table.
         source_asset_table = self.generate_asset_table()
         saved_asset_table = utils.clean_asset_table(

--- a/pretext/utils.py
+++ b/pretext/utils.py
@@ -19,7 +19,8 @@ from lxml.etree import _ElementTree, _Element
 from typing import Any, cast, List, Optional
 
 
-from . import core, templates, constants
+from . import core, templates
+from .project import Format
 
 # Get access to logger
 log = logging.getLogger("ptxlogger")
@@ -381,7 +382,7 @@ def show_target_hints(
     log.critical(
         f'There is not a target named "{target_format}" for this project.ptx manifest.'
     )
-    if target_format in constants.BUILD_FORMATS:
+    if target_format in [e.value for e in Format]:
         target_names = project.target_names(target_format)
         if len(target_names) == 1:
             log.info(

--- a/pretext/utils.py
+++ b/pretext/utils.py
@@ -19,8 +19,7 @@ from lxml.etree import _ElementTree, _Element
 from typing import Any, cast, List, Optional
 
 
-from . import core, templates
-from .project import Format
+from . import core, templates, constants
 
 # Get access to logger
 log = logging.getLogger("ptxlogger")
@@ -382,7 +381,7 @@ def show_target_hints(
     log.critical(
         f'There is not a target named "{target_format}" for this project.ptx manifest.'
     )
-    if target_format in [e.value for e in Format]:
+    if target_format in constants.FORMATS:
         target_names = project.target_names(target_format)
         if len(target_names) == 1:
             log.info(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -170,7 +170,9 @@ def test_generate_asymptote(tmp_path: Path, script_runner: ScriptRunner) -> None
 def test_generate_interactive(tmp_path: Path, script_runner: ScriptRunner) -> None:
     int_path = tmp_path / "interactive"
     shutil.copytree(EXAMPLES_DIR / "projects" / "interactive", int_path)
-    assert script_runner.run([PTX_CMD, "-v", "debug", "generate"], cwd=int_path).success
+    assert script_runner.run(
+        [PTX_CMD, "-v", "debug", "generate", "-t", "pdf"], cwd=int_path
+    ).success
     preview_file = (
         int_path / "generated-assets" / "preview" / "interactive-infinity-preview.png"
     )

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -306,9 +306,6 @@ def test_demo_html_build(tmp_path: Path) -> None:
         shutil.rmtree(t_web.generated_dir_abspath(), ignore_errors=True)
         t_web.build()
         assert t_web.output_dir_abspath().exists()
-        assert (
-            t_web.generated_dir_abspath() / "play-button" / "play-button.png"
-        ).exists()
         with open(t_web.output_dir_abspath() / ".mapping.json") as mpf:
             mapping = json.load(mpf)
         # This mapping will vary if the project structure produced by ``pretext new`` changes. Be sure to keep these in sync!


### PR DESCRIPTION
This will close #435.  It maintains a list of which assets could be used for each format, and filters by those early in the generate_assets method.

Also cleans up constants.BUILD_FORMATS which was left over from legacy and was only used in one help utility.