### PR TITLE
skip targets with invalid publication files

### DIFF
--- a/pretext/project/__init__.py
+++ b/pretext/project/__init__.py
@@ -1114,7 +1114,9 @@ class Project(pxml.BaseXmlModel, tag="project", search_mode=SearchMode.UNORDERED
 
                 # Ensure publication file exists (necessary for v2 validation)
                 if not Path(tgt.publication).exists():
-                    log.warning(f"Publication file at {tgt.publication} does not exist.")
+                    log.warning(
+                        f"Publication file at {tgt.publication} does not exist."
+                    )
                     log.warning(f"{tgt.name} will not be available.")
                     continue
 

--- a/pretext/project/__init__.py
+++ b/pretext/project/__init__.py
@@ -1115,7 +1115,8 @@ class Project(pxml.BaseXmlModel, tag="project", search_mode=SearchMode.UNORDERED
                 # Ensure publication file exists (necessary for v2 validation)
                 if not Path(tgt.publication).exists():
                     log.warning(f"Publication file at {tgt.publication} does not exist.")
-                    tgt.publication = None
+                    log.warning(f"{tgt.name} will not be available.")
+                    continue
 
                 # Remove the `None` from optional values, so the new format can replace these.
                 for key in ("site", "xsl", "latex_engine"):


### PR DESCRIPTION
This should ensure that v1 project files with targets that have non-existent publication files still validate (but those targets with bad publication files won't be available).