### PR TITLE
Validation

### DIFF
--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -70,12 +70,14 @@ def nice_errors(f: Callable[..., None]) -> Any:
                     log.error(
                         f"One of the targets has an attribute with illegal value: @{error['loc'][0]}=\"{error['input']}\" is not allowed.  Pick from the values:{error['msg'].split(': ')[-1].replace('Input should be','')}."
                     )
-                elif error["type"] == 'extra_forbidden':
+                elif error["type"] == "extra_forbidden":
                     log.error(
                         f"Either one of the targets or the root project element has an extra attribute it shouldn't: {error['loc'][0]}=\"{error['input']}\""
                     )
-                elif error['type'] == 'value_error':
-                    log.error(f"In at least one target, you cannot have @{error['loc'][0]}=\"{error['input']}\".  {error['msg'].replace('Value error, ','')}")
+                elif error["type"] == "value_error":
+                    log.error(
+                        f"In at least one target, you cannot have @{error['loc'][0]}=\"{error['input']}\".  {error['msg'].replace('Value error, ','')}"
+                    )
                 else:
                     log.error(f"{error['msg']} ({error['loc']}; {error['type']})")
             log.debug(

--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -57,17 +57,25 @@ def nice_errors(f: Callable[..., None]) -> Any:
             return ctx.invoke(f, *args, **kwargs)
         except ValidationError as e:
             log.critical(
-                "Failed to parse project.ptx. Please fix the following errors:"
+                "Failed to parse project.ptx. Check the entire file, including all targets, and fix the following errors:"
             )
+            print(e)
             for error in e.errors():
-                if error["type"] == "value_error.missing":
+                print(error)
+                if error["type"] == "missing":
                     log.error(
-                        f"There is a missing required attribute: {error['loc'][0]}."
+                        f"One of the targets has a missing required attribute: {error['loc'][0]}; look for the target with {error['input']}."
                     )
-                elif error["type"] == "type_error.enum":
+                elif error["type"] == "enum":
                     log.error(
-                        f"Incorrect value for the attribute `{error['loc']}`.  Pick from {error['msg'].split(': ')[-1]}."
+                        f"One of the targets has an attribute with illegal value: @{error['loc'][0]}=\"{error['input']}\" is not allowed.  Pick from the values:{error['msg'].split(': ')[-1].replace('Input should be','')}."
                     )
+                elif error["type"] == 'extra_forbidden':
+                    log.error(
+                        f"Either one of the targets or the root project element has an extra attribute it shouldn't: {error['loc'][0]}=\"{error['input']}\""
+                    )
+                elif error['type'] == 'value_error':
+                    log.error(f"In at least one target, you cannot have @{error['loc'][0]}=\"{error['input']}\".  {error['msg'].replace('Value error, ','')}")
                 else:
                     log.error(f"{error['msg']} ({error['loc']}; {error['type']})")
             log.debug(

--- a/pretext/project/__init__.py
+++ b/pretext/project/__init__.py
@@ -275,12 +275,12 @@ class Target(pxml.BaseXmlModel, tag="target", search_mode=SearchMode.UNORDERED):
                 # TODO: this is wrong, since the returned path is only valid inside the context manager. Instead, need to enter the context here, then exit it when this class is deleted (also problematic).
                 with templates.resource_path("publication.ptx") as self.publication:
                     pass
-        # Otherwise, verify that the provided publication file exists. TODO: perhaps skip this, instead reporting a file open error when this is read?
+        # Otherwise, verify that the provided publication file exists. TODO: It is silly to check that all publication files exist.  We warn when they don't.  If the target we are calling has a non-existent publication file, then that error will be caught anyway.
         else:
             p_full = self.publication_abspath()
             if not p_full.exists():
-                raise FileNotFoundError(
-                    f"Provided publication file {p_full} does not exist."
+                log.warning(
+                    f'The target "{self.name}" has a specified publication file that does not exist: {p_full}'
                 )
         # Pass `Project.asy_method` to `Target.asy_method` if it's not specified.
         self.asy_method = self.asy_method or self._project.asy_method

--- a/pretext/utils.py
+++ b/pretext/utils.py
@@ -158,8 +158,7 @@ def xml_syntax_is_valid(xmlfile: Path, root_tag: str = "pretext") -> bool:
             return False
     # check for file IO error
     except IOError:
-        log.error(f"The file {xmlfile} does not exist")
-        return False
+        raise IOError(f"The file {xmlfile} does not exist")
     # check for XML syntax errors
     except ET.XMLSyntaxError as err:
         log.error("XML Syntax Error caused build to fail:")


### PR DESCRIPTION
This improves error messages caused by validation errors, and relaxes the requirement that a publication file exists for all targets.  We catch non-existent publication files later in the process anyway.