### PR TITLE
improve static file replacement; use nojekyll

### DIFF
--- a/pretext/core/resources.py
+++ b/pretext/core/resources.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import zipfile
 import importlib.resources
+import shutil
 from .. import CORE_COMMIT
 
 
@@ -21,6 +22,15 @@ def path(*args: str) -> Path:
 
 
 def install(local_base_path: Path) -> None:
+    backup_dir = local_base_path.with_name(local_base_path.name + ".bak")
+    if Path.is_dir(backup_dir):
+        # remove old backup:
+        shutil.rmtree(backup_dir)
+    if Path.is_dir(local_base_path):
+        print(f"Backing up old static files to {backup_dir}")
+        Path.rename(local_base_path, backup_dir)
+    Path.mkdir(local_base_path)
+
     with importlib.resources.path("pretext.core", "resources.zip") as static_zip:
         with zipfile.ZipFile(static_zip, "r") as zip:
             zip.extractall(local_base_path)

--- a/pretext/utils.py
+++ b/pretext/utils.py
@@ -576,7 +576,7 @@ def publish_to_ghpages(directory: Path, update_source: bool) -> None:
     ghp_import.ghp_import(
         directory,
         mesg="Latest build deployed.",
-        nojekyll=False,
+        nojekyll=True,
     )
     log.info(f"Attempting to connect to remote repository at `{origin.url}`...")
     # log.info("(Your SSH password may be required.)")


### PR DESCRIPTION
This will fix the issue with github pages not seeing the static files (previously jekyll assumed that anything starting with an underscore should be ignored)