### PR TITLE
Prefix tmp directories with pretext_

### DIFF
--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -283,7 +283,7 @@ def new(template: str, directory: Path, url_template: str) -> None:
     project_ptx_index = filenames.index("project.ptx")
     project_ptx_path = Path(archive.namelist()[project_ptx_index])
     project_dir_path = project_ptx_path.parent
-    with tempfile.TemporaryDirectory() as tmpdirname:
+    with tempfile.TemporaryDirectory(prefix="pretext_") as tmpdirname:
         temp_path = Path(tmpdirname) / "new-project"
         temp_path.mkdir()
         for filepath in [

--- a/pretext/project/__init__.py
+++ b/pretext/project/__init__.py
@@ -522,7 +522,7 @@ class Target(pxml.BaseXmlModel, tag="target", search_mode=SearchMode.UNORDERED):
         self.ensure_output_directory()
 
         # Proceed with the build
-        with tempfile.TemporaryDirectory() as tmp_xsl_str:
+        with tempfile.TemporaryDirectory(prefix="pretext_") as tmp_xsl_str:
             tmp_xsl_path = Path(tmp_xsl_str)
             # if custom xsl, copy it into a temporary directory (different from the building temporary directory)
             if (txp := self.xsl_abspath()) is not None:

--- a/scripts/fetch_core.py
+++ b/scripts/fetch_core.py
@@ -17,7 +17,7 @@ def main() -> None:
         f"https://github.com/PreTeXtBook/pretext/archive/{CORE_COMMIT}.zip"
     )
     archive = zipfile.ZipFile(io.BytesIO(r.content))
-    with tempfile.TemporaryDirectory() as tmpdirname:
+    with tempfile.TemporaryDirectory(prefix="pretext_") as tmpdirname:
         archive.extractall(tmpdirname)
         print("Creating zip of static folders")
         # Copy required folders to a single folder to be zipped:

--- a/scripts/zip_templates.py
+++ b/scripts/zip_templates.py
@@ -11,7 +11,7 @@ def main() -> None:
     for template_directory in glob.iglob("templates/[!.]*"):
         template_path = Path(template_directory)
         if template_path.is_dir():
-            with tempfile.TemporaryDirectory() as temporary_directory:
+            with tempfile.TemporaryDirectory(prefix="pretext_") as temporary_directory:
                 temporary_path = Path(temporary_directory)
                 shutil.copytree(
                     template_path,


### PR DESCRIPTION
This PR prefixes temporary directories that pretext creates with `pretext_` to make them easier to manage during debugging.

However, this PR seems to miss the creation of some directory, since my `/tmp` is littered with `tmp****` files that persist after `pretext build` has finished and contain the contents of the build.