### PR TITLE
revert behavior of view command

### DIFF
--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -728,7 +728,7 @@ def view(
         if no_launch:
             log.info(f"The {target_name} will be available at {url}")
         else:
-            SECONDS = 3
+            SECONDS = 5
             log.info(f"Opening browser for {target_name} at {url} in {SECONDS} seconds")
             time.sleep(SECONDS)
             webbrowser.open(url)
@@ -770,7 +770,7 @@ def view(
         if no_launch:
             log.info(f"The {target_name} will be available at {url}")
         else:
-            # SECONDS = 1
+            # SECONDS = 2
             log.info(f"Opening browser for {target_name} at {url}")
             # time.sleep(SECONDS)
             webbrowser.open(url)

--- a/pretext/utils.py
+++ b/pretext/utils.py
@@ -229,6 +229,7 @@ def serve_forever(
     binding = binding_for_access(access)
 
     # Previously we defined a custom handler to prevent caching, but we don't need to do that anymore.  It was causing issues with the _static js/css files inside codespaces for an unknown reason.  Might bring this back in the future.
+    # 2024-04-05: try using this again to let Firefox work
     class RequestHandler(SimpleHTTPRequestHandler):
         def __init__(self, *args: Any, **kwargs: Any):
             super().__init__(*args, directory=base_dir.as_posix(), **kwargs)
@@ -250,7 +251,7 @@ def serve_forever(
     looking_for_port = True
     while looking_for_port:
         try:
-            with TCPServer((binding, port), SimpleHTTPRequestHandler) as httpd:
+            with TCPServer((binding, port), RequestHandler) as httpd:
                 looking_for_port = False
                 httpd.serve_forever()
         except OSError:


### PR DESCRIPTION
Will close #710 

This does not add back in the delay for non-codespace use, but does put back the no-cache stuff, which I think is what is causing the issues with Firefox