### PR TITLE
logs below error sent to stdout

### DIFF
--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -46,7 +46,7 @@ mh = logging.handlers.MemoryHandler(
     capacity=1024 * 100, flushLevel=100, target=sh, flushOnClose=False
 )
 mh.setLevel(logging.ERROR)
-mh.setFormatter(sh.setFormatter(click_log.ColorFormatter()))
+mh.setFormatter(click_log.ColorFormatter())
 log.addHandler(mh)
 
 # Call exit_command() at close to handle errors encountered during run.

--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -47,7 +47,7 @@ error_handler = logging.handlers.MemoryHandler(
     capacity=1024 * 100,
     flushLevel=100,
     target=logging.StreamHandler(sys.stderr),
-    flushOnClose=False
+    flushOnClose=False,
 )
 error_handler.setLevel(logging.ERROR)
 error_handler.setFormatter(click_log.ColorFormatter())

--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -36,16 +36,17 @@ from . import (
 from .project import Project
 
 log = logging.getLogger("ptxlogger")
-click_log.basic_config(log)
-click_log_format = click_log.ColorFormatter()
+# Use a handler for standard out that works with click:
+click_handler = logging.StreamHandler(sys.stdout)
+click_handler.setFormatter(click_log.ColorFormatter())
+log.addHandler(click_handler)
 # create memory handler which displays error and critical messages at the end as well.
 sh = logging.StreamHandler(sys.stderr)
-sh.setFormatter(click_log_format)
 mh = logging.handlers.MemoryHandler(
     capacity=1024 * 100, flushLevel=100, target=sh, flushOnClose=False
 )
 mh.setLevel(logging.ERROR)
-mh.setFormatter(click_log_format)
+mh.setFormatter(sh.setFormatter(click_log.ColorFormatter()))
 log.addHandler(mh)
 
 # Call exit_command() at close to handle errors encountered during run.

--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -36,21 +36,25 @@ from . import (
 from .project import Project
 
 log = logging.getLogger("ptxlogger")
-# Use a handler for standard out that works with click:
+
+# click_handler logs all messages to stdout as the CLI runs
 click_handler = logging.StreamHandler(sys.stdout)
 click_handler.setFormatter(click_log.ColorFormatter())
 log.addHandler(click_handler)
-# create memory handler which displays error and critical messages at the end as well.
-sh = logging.StreamHandler(sys.stderr)
-mh = logging.handlers.MemoryHandler(
-    capacity=1024 * 100, flushLevel=100, target=sh, flushOnClose=False
+
+# error_handler captures error/critical logs for flushing to stderr at the end of a CLI run
+error_handler = logging.handlers.MemoryHandler(
+    capacity=1024 * 100,
+    flushLevel=100,
+    target=logging.StreamHandler(sys.stderr),
+    flushOnClose=False
 )
-mh.setLevel(logging.ERROR)
-mh.setFormatter(click_log.ColorFormatter())
-log.addHandler(mh)
+error_handler.setLevel(logging.ERROR)
+error_handler.setFormatter(click_log.ColorFormatter())
+log.addHandler(error_handler)
 
 # Call exit_command() at close to handle errors encountered during run.
-atexit.register(utils.exit_command, mh)
+atexit.register(utils.exit_command, error_handler)
 
 
 # Add a decorator to provide nice exception handling for validation errors for all commands. It avoids printing a confusing traceback, and also nicely formats validation errors.

--- a/pretext/utils.py
+++ b/pretext/utils.py
@@ -481,12 +481,12 @@ def exit_command(mh: logging.handlers.MemoryHandler) -> None:
     Checks to see if anything (errors etc.) is in the memory handler.  If it is, reports that there are errors before the handler gets flushed.  Otherwise, adds a single blank line.
     """
     if len(mh.buffer) > 0:
-        print("\n----------------------------------------------------")
+        log.info("\n----------------------------------------------------")
         log.info("While running pretext, the following errors occurred:\n")
         mh.flush()
-        print("----------------------------------------------------")
+        log.info("----------------------------------------------------")
     else:
-        print("")
+        log.info("")
 
 
 def format_docstring_as_help_str(string: str) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -182,7 +182,7 @@ def test_custom_webwork_server(tmp_path: Path, script_runner: ScriptRunner) -> N
         [PTX_CMD, "-v", "debug", "generate", "webwork"], cwd=custom_path
     )
     assert result.success
-    assert "webwork.runestone.academy" in result.stderr
+    assert "webwork.runestone.academy" in result.stdout
     result = script_runner.run([PTX_CMD, "-v", "debug", "build"], cwd=custom_path)
     assert result.success
 


### PR DESCRIPTION
This changes the logging of debug, info, and warning to go to stdout.  Actually, everything now goes to stdout, but at the end of the build, when we re-report errors and critical messages, those will go to stderr.

If we wanted warning to also go to stderr, we could either report those warning at the end, or would need to add some more logic to separate which messages go where.

This will close #660.  See also #336 