### PR TITLE
Clean the stage directory on each deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Instructions: Add a subsection under `[UNRELEASED]` for additions, fixes, change
 
 - Improved `pretext import` command to handle modular latex files better.
 - Turned off image conversions for `pretext import`.
+- Always stage to a clean stage directory for `pretext deploy`.
 
 ## [2.4.1] - 2024-05-18
 

--- a/pretext/project/__init__.py
+++ b/pretext/project/__init__.py
@@ -1283,7 +1283,10 @@ class Project(pxml.BaseXmlModel, tag="project", search_mode=SearchMode.UNORDERED
 
     def stage_deployment(self) -> None:
         # First empty the stage directory (as long as it is safely in the project directory).
-        if self.stage_abspath().exists() and self.abspath() in self.stage_abspath.parents:
+        if (
+            self.stage_abspath().exists()
+            and self.abspath() in self.stage_abspath().parents
+        ):
             shutil.rmtree(self.stage_abspath())
             log.debug("Removed old stage directory")
         # Ensure stage directory exists

--- a/pretext/project/__init__.py
+++ b/pretext/project/__init__.py
@@ -1282,6 +1282,10 @@ class Project(pxml.BaseXmlModel, tag="project", search_mode=SearchMode.UNORDERED
         return [target for target in self.targets if target.deploy_dir is not None]
 
     def stage_deployment(self) -> None:
+        # First empty the stage directory (as long as it is safely in the project directory).
+        if self.stage_abspath().exists() and self.abspath() in self.stage_abspath.parents:
+            shutil.rmtree(self.stage_abspath())
+            log.debug("Removed old stage directory")
         # Ensure stage directory exists
         self.stage_abspath().mkdir(parents=True, exist_ok=True)
         # Stage all configured targets for deployment


### PR DESCRIPTION
To ensure that there is not extra files in the stage directory, and to avoid issues with file name capitalization, every time deploy is called, we delete the stage directory and copy everything fresh.