### PR TITLE
Include HHMMSS in dev version

### DIFF
--- a/scripts/prep_nightly.py
+++ b/scripts/prep_nightly.py
@@ -61,7 +61,7 @@ def main() -> None:
     ):
         if line.startswith("version"):
             version = str(line.split('"')[1])
-            newversion = version + ".dev" + datetime.now().strftime("%Y%m%d")
+            newversion = version + ".dev" + datetime.now().strftime("%Y%m%d%H%M%S")
             print(line.replace(line, f'version = "{newversion}"'.rstrip()))
         else:
             print(line.rstrip())


### PR DESCRIPTION
This change includes HHMMSS in dev/nightly releases.

Rationale: should we want to push an extra dev release between nightlies, this ensures order is maintained. (Inspired by https://github.com/PreTeXtBook/pretext-cli/pull/740 where having a dev release available would have been handy to expriement with Codechat in a vanilla PreTeXt project.)