### PR TITLE
correct docstring for deploy

### DIFF
--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -842,7 +842,7 @@ def deploy(
     ctx: click.Context, update_source: bool, stage_only: bool, preview: bool
 ) -> None:
     """
-    Automatically deploys most recent build of [TARGET] to GitHub Pages,
+    Automatically deploys project to GitHub Pages,
     making it available to the general public.
     Requires that your project is under Git version control
     properly configured with GitHub and GitHub Pages. Deployed


### PR DESCRIPTION
Closes #683

@Alex-Jordan to choose which targets get deployed, set `deploy="yes"` (in current nightlies) or `deploy_dir="whatever"` on those targets. (If nothing is set, then deploy should still deploy the default target, but explicit is better.)