### PR TITLE
Use oscarlevin:full by default in codespace

### DIFF
--- a/templates/.devcontainer.json
+++ b/templates/.devcontainer.json
@@ -15,9 +15,9 @@
   "name": "PreTeXt-Codespaces",
 
   // This Docker image includes some LaTeX support, but is still not to large.  Note that if you keep your codespace running, it will use up your GitHub free storage quota.  Additional options are listed below.
-  "image": "oscarlevin/pretext:small",
+  // "image": "oscarlevin/pretext:small",
   // If you need to generate more complicated assets (such as sageplots) or use additional fonts when building to PDF, comment out the above line and uncomment the following line.
-  // "image": "oscarlevin/pretext:full",
+  "image": "oscarlevin/pretext:full",
   // If you only intend to build for web and don't have any latex-image generated assets, you can use a smaller image:
   // "image": "oscarlevin/pretext:lite",
 


### PR DESCRIPTION
Would have prevented https://groups.google.com/g/pretext-support/c/5EhXaz_MHwA/m/iRtDPVbRCAAJ - I don't think the extra minute saved is worth the headache of explaining to users how to get Sage installed in their codespace.