### PR TITLE
remove pymupdf options

### DIFF
--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -523,10 +523,10 @@ def build(
     help="Generate all possible asset formats rather than just the defaults for the specified target.",
 )
 @click.option(
-    "--pymupdf",
+    "--non-pymupdf",
     is_flag=True,
     default=False,
-    help="Used to test new pyMuPDF method for generating svg and png.",
+    help="Used to revert to non-pymupdf (legacy) method for generating svg and png.",
 )
 @nice_errors
 def generate(
@@ -535,7 +535,7 @@ def generate(
     all_formats: bool,
     only_changed: bool,
     xmlid: Optional[str],
-    pymupdf: bool,
+    non_pymupdf: bool,
 ) -> None:
     """
     Generate specified (or all) assets for the default target (first target in "project.ptx"). Asset "generation" is typically
@@ -572,7 +572,7 @@ def generate(
             all_formats=all_formats,
             only_changed=only_changed,  # Unless requested, generate all assets, so don't check the cache.
             xmlid=xmlid,
-            pymupdf=pymupdf,
+            non_pymupdf=non_pymupdf,
         )
         log.info("Finished generating assets.\n")
     except ValidationError as e:

--- a/pretext/project/__init__.py
+++ b/pretext/project/__init__.py
@@ -865,7 +865,7 @@ class Target(pxml.BaseXmlModel, tag="target", search_mode=SearchMode.UNORDERED):
                             dest_dir=self.generated_dir_abspath() / "latex-image",
                             outformat=outformat,
                             method=self.latex_engine,
-                            pyMuPDF=not(non_pymupdf),
+                            pyMuPDF=not (non_pymupdf),
                         )
                     successful_assets.append(("latex-image", id))
                 except Exception as e:

--- a/pretext/project/__init__.py
+++ b/pretext/project/__init__.py
@@ -688,7 +688,7 @@ class Target(pxml.BaseXmlModel, tag="target", search_mode=SearchMode.UNORDERED):
         all_formats: bool = False,
         only_changed: bool = True,
         xmlid: t.Optional[str] = None,
-        pymupdf: bool = False,
+        non_pymupdf: bool = False,
     ) -> None:
         """
         Generates assets for the current target.  Options:
@@ -696,7 +696,7 @@ class Target(pxml.BaseXmlModel, tag="target", search_mode=SearchMode.UNORDERED):
            - all_formats: boolean to decide whether the output format of the assets will be just those that the target format uses (default/False) or all possible output formats for that asset (True).
            - only_changed: boolean.  When True (default), function will only generate assets that have changed since last generation.  When False, all assets will be built (hash table will be ignored).
            - xmlid: optional string to specify the root of the subtree of the xml document to generate assets within.
-           - pymupdf: temporary boolean to test alternative image generation with pymupdf instead of external programs.
+           - non_pymupdf: temporary boolean to revert to legacy alternative image generation without pymupdf (and use old external programs).
         """
         # Start by getting the assets that need to be generated for the particular target.  This will either be all of them, or just the asset type that was specifically requested.
         if requested_asset_types is None or "ALL" in requested_asset_types:
@@ -865,7 +865,7 @@ class Target(pxml.BaseXmlModel, tag="target", search_mode=SearchMode.UNORDERED):
                             dest_dir=self.generated_dir_abspath() / "latex-image",
                             outformat=outformat,
                             method=self.latex_engine,
-                            pyMuPDF=pymupdf,
+                            pyMuPDF=not(non_pymupdf),
                         )
                     successful_assets.append(("latex-image", id))
                 except Exception as e:


### PR DESCRIPTION
An upcoming PR to core pretext will make pyMuPDF the only way to generate latex images, so the option to enable this for the CLI is no longer needed. 

Keeping as draft until the core PR is approved.