### PR TITLE
Add support for dynamic-substitutions (dynamic-subs)

### DIFF
--- a/pretext/constants.py
+++ b/pretext/constants.py
@@ -24,6 +24,7 @@ ASSETS_BY_FORMAT = {
         "datafile",
         "interactive",
         "mermaid",
+        "dynamic-subs",
     ],
     "latex": [
         "webwork",
@@ -34,6 +35,7 @@ ASSETS_BY_FORMAT = {
         "datafile",
         "interactive",
         "mermaid",
+        "dynamic-subs",
     ],
     "epub": [
         "webwork",
@@ -45,6 +47,7 @@ ASSETS_BY_FORMAT = {
         "datafile",
         "interactive",
         "mermaid",
+        "dynamic-subs",
     ],
     "kindle": [
         "webwork",
@@ -56,6 +59,7 @@ ASSETS_BY_FORMAT = {
         "datafile",
         "interactive",
         "mermaid",
+        "dynamic-subs",
     ],
     "braille": [
         "webwork",
@@ -67,6 +71,7 @@ ASSETS_BY_FORMAT = {
         "datafile",
         "interactive",
         "mermaid",
+        "dynamic-subs",
     ],
     "webwork": [
         "webwork",
@@ -81,6 +86,7 @@ ASSETS_BY_FORMAT = {
         "datafile",
         "interactive",
         "mermaid",
+        "dynamic-subs",
     ],
 }
 
@@ -94,6 +100,7 @@ ASSET_TO_XPATH = {
     "datafile": ".//datafile",
     "interactive": ".//interactive",
     "mermaid": ".//mermaid",
+    "dynamic-subs": ".//statement[.//fillin and ancestor::exercise/evaluation]",
 }
 ASSETS = ["ALL"] + list(ASSET_TO_XPATH.keys())
 
@@ -107,6 +114,7 @@ ASSET_TO_DIR = {
     "codelens": ["trace"],
     "datafile": ["datafile"],
     "mermaid": ["mermaid"],
+    "dynamic-subs": ["dynamic_subs"],
 }
 
 ASSET_FORMATS: t.Dict[str, t.Dict[str, t.List[str]]] = {

--- a/pretext/project/__init__.py
+++ b/pretext/project/__init__.py
@@ -950,6 +950,22 @@ class Target(pxml.BaseXmlModel, tag="target", search_mode=SearchMode.UNORDERED):
                 except Exception as e:
                     log.error(f"Unable to generate some mermaid images: \n{e}")
                     log.debug(e, exc_info=True)
+        if "dynamic-subs" in assets_to_generate:
+            try:
+                core.dynamic_substitutions(
+                    xml_source=self.source_abspath(),
+                    pub_file=self.publication_abspath().as_posix(),
+                    stringparams=stringparams_copy,
+                    xmlid_root=xmlid,
+                    dest_dir=self.generated_dir_abspath() / "dynamic_subs",
+                )
+                for id in assets_to_generate["dynamic-subs"]:
+                    successful_assets.append(("dynamic-subs", id))
+            except Exception as e:
+                log.error(
+                    f"Unable to extract some dynamic exercise substitutions: \n{e}"
+                )
+                log.debug(e, exc_info=True)
         if "codelens" in assets_to_generate:
             for id in assets_to_generate["codelens"]:
                 try:


### PR DESCRIPTION
* New generated asset: dynamic-subs

---

I ran the formatting and attempted the tests but didn't have sage installed locally to finish the test. I did verify that the generated assets file was created when called and that the print target successfully generated on its own.