### PR TITLE
move exit command to end of appropriate cli commands

### DIFF
--- a/pretext/utils.py
+++ b/pretext/utils.py
@@ -496,10 +496,14 @@ def exit_command(mh: logging.handlers.MemoryHandler) -> None:
     if has_errors(mh):
         log.info("\n----------------------------------------------------")
         log.info("While running pretext, the following errors occurred:\n")
+        log.info(
+            "(see log messages above or in the 'logs' folder for more information)"
+        )
         mh.flush()
         log.info("----------------------------------------------------")
         raise SystemExit(1)
     else:
+        log.debug("Completed without errors.")
         log.info("")
 
 


### PR DESCRIPTION
To address #780.  This does what we want, without importing `at_exit`.  But slightly more brittle code, requiring new CLI commands to remember to call `utils.exit_command` as their last thing.