### PR TITLE
fix duplicate id bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Instructions: Add a subsection under `[UNRELEASED]` for additions, fixes, change
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Bug with html build for source with version controlled components with duplicate ids.
+
 ## [2.5.1] - 2024-07-16
 
 ### Fixed

--- a/pretext/project/__init__.py
+++ b/pretext/project/__init__.py
@@ -635,11 +635,18 @@ class Target(pxml.BaseXmlModel, tag="target", search_mode=SearchMode.UNORDERED):
                     out_file=out_file,
                     dest_dir=self.output_dir_abspath().as_posix(),
                 )
-                codechat.map_path_to_xml_id(
-                    self.source_abspath(),
-                    self._project.abspath(),
-                    self.output_dir_abspath().as_posix(),
-                )
+                try:
+                    codechat.map_path_to_xml_id(
+                        self.source_abspath(),
+                        self._project.abspath(),
+                        self.output_dir_abspath().as_posix(),
+                    )
+                except Exception as e:
+                    log.warning(
+                        "Failed to map codechat path to xml id; codechat will not work."
+                    )
+                    log.debug(f"Error: {e}")
+                    log.debug("Traceback:", exc_info=True)
             elif self.format == Format.PDF:
                 core.pdf(
                     xml=self.source_abspath(),


### PR DESCRIPTION
Codechat parses the xml it complains and causes a critical error when there are duplicate `xml:ids` even if they are in separate components only one of which is included in a particular `version`.  

This just wraps the codechat `map_path_to_xml_id` in a `try/except` as a stop-gap until this is fixed.  Or maybe we never fix it, since it is very unlikely someone with this sort of structure would use codechat anyway.

FYI @StevenClontz and @bjones1. 