### PR TITLE
Fix two deprecations in slideshow template

### DIFF
--- a/templates/slideshow/publication/publication.ptx
+++ b/templates/slideshow/publication/publication.ptx
@@ -26,7 +26,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <appearance theme="solarized"/>
         <!-- these are "resources" defaults, but best for a sample -->
         <!-- @minified is not even necessary with @host = 'cdn'    -->
-        <resources host="cdn" minified="yes"/>
+        <resources host="cdn"/>
         <!-- display="yes" is the default so we can see arrows          -->
         <!-- tutorial="yes" is the default                              -->
         <!-- layout="bottom-right" is the default, "edges" is an option -->

--- a/templates/slideshow/source/main.ptx
+++ b/templates/slideshow/source/main.ptx
@@ -73,7 +73,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
                 <p>These are enumerated with capital letters.</p>
 
-                <p><ol label="A">
+                <p><ol marker="A">
                     <li>Two conversions: print-on-demand, electronic <init>PDF</init></li>
                     <li>Extensive use of the <c>tcolorbox</c> package (CSS-like)</li>
                     <li>Evolving styling/themes (Andrew Rechnitzer, David Farmer)</li>
@@ -81,7 +81,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
                 <p>These are inline</p>
 
-                <p><ol label="i" cols="2">
+                <p><ol marker="i" cols="2">
                     <li>print-on-demand</li>
                     <li>electronic <init>PDF</init></li>
                 </ol></p>


### PR DESCRIPTION
The template produced by `pretext new slideshow` produces two deprecation errors:
1. The `minified` option is obsolete and no longer supported
2. Lists now use `marker` instead of `label` 

I've removed the minified option from the publisher file, and changed label to marker in two lists.