### PR TITLE
Avoid zombies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Instructions: Add a subsection under `[UNRELEASED]` for additions, fixes, change
 
 ## [UNRELEASED]
 
+### Fixed
+
+- `pretext view` should now work even if a previous view process did not exit properly.
+
 ## [2.6.0] - 2024-07-18
 
 ### Changed

--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -697,9 +697,14 @@ def view(
 
     # pretext view -s should immediately stop the server and do nothing else.
     if stop_server:
-        log.info("\nStopping server.")
-        utils.stop_server()
-        return
+        try:
+            log.info("\nStopping server.")
+            utils.stop_server()
+        except Exception as e:
+            log.warning("Failed to stop server.")
+            log.debug("e", exc_info=True)
+        finally:
+            return
     if utils.cannot_find_project(task="view the output for"):
         return
     project = Project.parse()
@@ -771,7 +776,12 @@ def view(
         log.info("")
         # First terminate any existing server using this port
         if used_port == port:
-            utils.stop_server(used_port)
+            try:
+                utils.stop_server(used_port)
+            except Exception as e:
+                log.warning("Failed to stop server.")
+                log.debug("e", exc_info=True)
+                pass
         # Start the new server
         server = project.server_process(
             access=access,

--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -702,7 +702,7 @@ def view(
             utils.stop_server()
         except Exception as e:
             log.warning("Failed to stop server.")
-            log.debug("e", exc_info=True)
+            log.debug(e, exc_info=True)
         finally:
             return
     if utils.cannot_find_project(task="view the output for"):
@@ -780,7 +780,7 @@ def view(
                 utils.stop_server(used_port)
             except Exception as e:
                 log.warning("Failed to stop server.")
-                log.debug("e", exc_info=True)
+                log.debug(e, exc_info=True)
                 pass
         # Start the new server
         server = project.server_process(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,10 +79,13 @@ build-backend = "poetry.core.masonry.api"
 [[tool.poetry.source]]
 name = "pypi-public"
 url = "https://pypi.org/simple/"
+priority = "primary"
 
 
-# Pytest configuration
-# ====================
+[[tool.poetry.source]]
+name = "PyPI"
+priority = "primary"
+
 [tool.pytest.ini_options]
 script_launch_mode = "subprocess"
 


### PR DESCRIPTION
I think this will close #651.  We try to kill a pretext process when we run view, but if this is a zombie process (which might be happening because adobe acrobat has messed something else, although this is just speculation) this fails and does not allow view to proceed.

This puts that logic inside a try/except block to hopefully make this no longer an issue. 