### PR TITLE
Fix webwork sets bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Instructions: Add a subsection under `[UNRELEASED]` for additions, fixes, change
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Bug preventing the extraction of webwork sets.
+
 ### Updated
 
 - Bumped `lxml` to at least 5.3 and `psutils` to at least 6.0.

--- a/pretext/constants.py
+++ b/pretext/constants.py
@@ -167,6 +167,12 @@ ASSET_FORMATS: t.Dict[str, t.Dict[str, t.List[str]]] = {
         "sageplot": ["all"],
         "mermaid": ["png"],
     },
+    "webwork": {
+        "asymptote": [],
+        "latex-image": [],
+        "sageplot": [],
+        "mermaid": [],
+    },
     "custom": {
         "asymptote": ["all"],
         "latex-image": ["all"],


### PR DESCRIPTION
The `constants.ASSET_FORMATS["webwork"]` was missing.

Will close #823 