### PR TITLE
fix up github action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Instructions: Add a subsection under `[UNRELEASED]` for additions, fixes, change
 
 ### Updated
 
+- Github action will test build on older versions listed in requirements.
 - Bumped `lxml` to at least 5.3 and `psutils` to at least 6.0.
 
 ## [2.6.2] - 2024-08-21

--- a/templates/pretext-cli.yml
+++ b/templates/pretext-cli.yml
@@ -24,8 +24,21 @@ jobs:
             - name: install deps
               run: pip install -r requirements.txt
 
+            - name: install local ptx files
+              run: pretext --version
+
             - name: build deploy targets
-              run: pretext build --deploys
+              run: |
+                version="$(pretext --version)"
+                major="$(echo $version | cut -d '.' -f 1)"
+                minor="$(echo $version | cut -d '.' -f 2)"
+                if [ "$major" -ge 2 -a "$minor" -ge 5 ]; then
+                    echo "PreTeXt version is 2.5 or greater; using new build command"
+                    pretext build --deploys
+                else
+                    echo "PreTeXt version is less than 2.5, using old build command"
+                    pretext build
+                fi
             - name: stage deployment
               run: pretext deploy --stage-only
 


### PR DESCRIPTION
The action for push will now check to ensure that version 2.5 or greater is installed before running `pretext build --deploys`, and run `pretext build` if not.  

Closes #824 