### PR TITLE
implement npm install for cssbundling

### DIFF
--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -399,6 +399,12 @@ def init(refresh: bool, files: List[str]) -> None:
     help="Do not generate assets for target, even if their source has changed since the last time they were generated.",
 )
 @click.option(
+    "-t",
+    "--theme",
+    is_flag=True,
+    help="Only build the theme for the target, without performing any other build or generate steps.  (Themes are automatically built when building a target.)",
+)
+@click.option(
     "-x",
     "--xmlid",
     type=click.STRING,
@@ -420,6 +426,7 @@ def build(
     clean: bool,
     generate: bool,
     no_generate: bool,
+    theme: bool,
     xmlid: Optional[str],
     no_knowls: bool,
     deploys: bool,
@@ -453,6 +460,18 @@ def build(
         log.critical("Exiting without completing build.")
         log.debug(e, exc_info=True)
         return
+
+    # If theme flag is set, only build the theme
+    if theme:
+        try:
+            for t in targets:
+                t.build_theme()
+        except Exception as e:
+            log.error(f"Failed to build theme: {e}")
+            log.debug("Exception info:\n------------------------\n", exc_info=True)
+        finally:
+            # Theme flag means to only build the theme, so we...
+            return
 
     # Call generate if flag is set
     if generate and not no_generate:

--- a/pretext/project/__init__.py
+++ b/pretext/project/__init__.py
@@ -634,6 +634,11 @@ class Target(pxml.BaseXmlModel, tag="target", search_mode=SearchMode.UNORDERED):
                         log.warning(
                             "The platform host in the publication file is not set to runestone. Since the requested target has @platform='runestone', we will override the publication file's platform host."
                         )
+                utils.ensure_css(
+                    xml=self.source_abspath(),
+                    pub_file=self.publication_abspath().as_posix(),
+                    stringparams=stringparams_copy,
+                )
                 core.html(
                     xml=self.source_abspath(),
                     pub_file=self.publication_abspath().as_posix(),
@@ -681,7 +686,7 @@ class Target(pxml.BaseXmlModel, tag="target", search_mode=SearchMode.UNORDERED):
                     generated_abs=self.generated_dir_abspath(),
                 )
             elif self.format == Format.EPUB:
-                utils.npm_install()
+                utils.mjsre_npm_install()
                 core.epub(
                     xml_source=self.source_abspath(),
                     pub_file=self.publication_abspath().as_posix(),
@@ -691,7 +696,7 @@ class Target(pxml.BaseXmlModel, tag="target", search_mode=SearchMode.UNORDERED):
                     stringparams=stringparams_copy,
                 )
             elif self.format == Format.KINDLE:
-                utils.npm_install()
+                utils.mjsre_npm_install()
                 core.epub(
                     xml_source=self.source_abspath(),
                     pub_file=self.publication_abspath().as_posix(),
@@ -715,7 +720,7 @@ class Target(pxml.BaseXmlModel, tag="target", search_mode=SearchMode.UNORDERED):
                 log.warning(
                     "Braille output is still experimental, and requires additional libraries from liblouis (specifically the file2brl software)."
                 )
-                utils.npm_install()
+                utils.mjsre_npm_install()
                 core.braille(
                     xml_source=self.source_abspath(),
                     pub_file=self.publication_abspath().as_posix(),

--- a/pretext/project/__init__.py
+++ b/pretext/project/__init__.py
@@ -554,6 +554,31 @@ class Target(pxml.BaseXmlModel, tag="target", search_mode=SearchMode.UNORDERED):
             )
             shutil.rmtree(self.output_dir_abspath())
 
+    def build_theme(self) -> None:
+        """
+        Builds or copies the theme for an HTML-formatted target.
+        """
+        # if the format of target is not HTML, do nothing with a warning.
+        if self.format != Format.HTML:
+            log.warning(
+                f"Theme building is only supported for HTML targets, not {self.format}."
+            )
+            return
+        # Call the core function to build and/or copy the theme to the output folder
+        log.info(f"Building theme for target '{self.name}'")
+        utils.ensure_css(
+            xml=self.source_abspath(),
+            pub_file=self.publication_abspath().as_posix(),
+            stringparams=self.stringparams,
+        )
+        core.build_or_copy_theme(
+            xml=self.source_abspath(),
+            pub_file=self.publication_abspath().as_posix(),
+            stringparams=self.stringparams,
+            tmp_dir=self.output_dir_abspath().as_posix(),
+        )
+        log.info(f"Theme built for target '{self.name}'")
+
     def build(
         self,
         clean: bool = False,

--- a/pretext/utils.py
+++ b/pretext/utils.py
@@ -458,7 +458,7 @@ def show_target_hints(
         )
 
 
-def npm_install() -> None:
+def mjsre_npm_install() -> None:
     with working_directory(
         resources.resource_base_path() / "core" / "script" / "mjsre"
     ):
@@ -468,6 +468,33 @@ def npm_install() -> None:
         except Exception as e:
             log.critical(
                 "Unable to install required npm packages.  Please see the documentation."
+            )
+            log.critical(e)
+            log.debug("", exc_info=True)
+
+
+def ensure_css(xml, pub_file, stringparams) -> None:
+    theme = core.get_publisher_variable(xml, pub_file, stringparams, "html-theme-name")
+    if "-legacy" in theme or theme == "default-modern":
+        log.debug("Using prebuilt theme, no need for sass build.")
+        return
+    # Otherwise we look for node_modules and install if we can.
+    with working_directory(
+        resources.resource_base_path() / "core" / "script" / "cssbuilder"
+    ):
+        # Check if node_modules is already present:
+        if "node_modules".exists():
+            log.debug("Node modules already installed.")
+            return
+        # If not, try to install them:
+        log.debug(
+            "Attempting to install/update required node packages to generate css from sass."
+        )
+        try:
+            subprocess.run("npm install", shell=True)
+        except Exception as e:
+            log.critical(
+                "Unable to install required npm packages to build css files.  To use your selected HTML theme, you must have node.js and npm installed."
             )
             log.critical(e)
             log.debug("", exc_info=True)

--- a/pretext/utils.py
+++ b/pretext/utils.py
@@ -99,8 +99,8 @@ def project_xml(dirpath: t.Optional[Path] = None) -> _ElementTree:
         dirpath = Path()  # current directory
     pp = project_path(dirpath)
     if pp is None:
-        with resources.resource_base_path() / "templates" / "project.ptx" as project_manifest:
-            return ET.parse(project_manifest)
+        project_manifest = resources.resource_base_path() / "templates" / "project.ptx"
+        return ET.parse(project_manifest)
     else:
         project_manifest = pp / "project.ptx"
         return ET.parse(project_manifest)
@@ -473,7 +473,7 @@ def mjsre_npm_install() -> None:
             log.debug("", exc_info=True)
 
 
-def ensure_css(xml, pub_file, stringparams) -> None:
+def ensure_css(xml: Path, pub_file: str, stringparams: t.Dict[str, str]) -> None:
     try:
         theme = core.get_publisher_variable(
             xml, pub_file, stringparams, "html-theme-name"

--- a/pretext/utils.py
+++ b/pretext/utils.py
@@ -474,7 +474,14 @@ def mjsre_npm_install() -> None:
 
 
 def ensure_css(xml, pub_file, stringparams) -> None:
-    theme = core.get_publisher_variable(xml, pub_file, stringparams, "html-theme-name")
+    try:
+        theme = core.get_publisher_variable(
+            xml, pub_file, stringparams, "html-theme-name"
+        )
+    except Exception as e:
+        log.debug("Could not get html-theme-name from publisher file.")
+        log.debug(e, exc_info=True)
+        return
     if "-legacy" in theme or theme == "default-modern":
         log.debug("Using prebuilt theme, no need for sass build.")
         return
@@ -483,7 +490,7 @@ def ensure_css(xml, pub_file, stringparams) -> None:
         resources.resource_base_path() / "core" / "script" / "cssbuilder"
     ):
         # Check if node_modules is already present:
-        if "node_modules".exists():
+        if Path("node_modules").exists():
             log.debug("Node modules already installed.")
             return
         # If not, try to install them:


### PR DESCRIPTION
Add a check to see whether the css will need to be generated by from sass, and if so, ensure that the node_modules have been installed in the core resources.  

Will keep this as a draft until the new html styling work is part of core making this relevant.

In the mean time, feel free to weigh in, @ascholerChemeketa 