### PR TITLE
Fix view for the case where a process is terminated abnormally

### DIFF
--- a/pretext/server.py
+++ b/pretext/server.py
@@ -40,7 +40,6 @@ class RunningServerInfo:
 
     def is_active_server(self) -> bool:
         """Returns whether the server represented by this object is active on the provided port"""
-        print("here!")
         try:
             p = psutil.Process(self.pid)
         except psutil.NoSuchProcess:

--- a/pretext/server.py
+++ b/pretext/server.py
@@ -40,7 +40,11 @@ class RunningServerInfo:
 
     def is_active_server(self) -> bool:
         """Returns whether the server represented by this object is active on the provided port"""
-        p = psutil.Process(self.pid)
+        print("here!")
+        try:
+            p = psutil.Process(self.pid)
+        except psutil.NoSuchProcess:
+            return False
         if not p.is_running():
             log.info(f"Found entry no longer running {p.pid}")
             return False


### PR DESCRIPTION
If a process no longer exists, `psutil.Process` throws an exception and we must catch it.