### PR TITLE
improve view command for codespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,18 @@ Instructions: Add a subsection under `[Unreleased]` for additions, fixes, change
 
 ## [Unreleased]
 
+### Fixed
+
+- Improved codespace view command (now respects already running servers).
+- CSS fixes for logo and references from core.
+
 ## [2.11.1] - 2024-12-25
 
 Includes updates to core through commit: [e4edfd0](https://github.com/PreTeXtBook/pretext/commit/e4edfd0fe052d9dd91404667a42ff1c0932d114b)
+
+### Fixed
+
+- `pretext view` bug where a process is terminated abnormally
 
 ## [2.11.0] - 2024-12-24
 

--- a/pretext/__init__.py
+++ b/pretext/__init__.py
@@ -21,7 +21,7 @@ log = logging.getLogger("ptxlogger")
 
 VERSION = get_version("pretext", Path(__file__).parent.parent)
 
-CORE_COMMIT = "e4edfd0fe052d9dd91404667a42ff1c0932d114b"
+CORE_COMMIT = "3c662c9fc70c6fa49c031c44ffaebcfbf61ce2f1"
 
 
 def activate() -> None:


### PR DESCRIPTION
View command will now use the running_servers file to not start new servers even if inside a codespace.