### PR TITLE
update workflow to use container for deep test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,11 +45,10 @@ jobs:
       - name: Install apt packages (Linux with python 3.12 only)
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends texlive texlive-science texlive-xetex ghostscript pdf2svg texlive-fonts-extra sagemath
+          sudo apt-get install -y --no-install-recommends texlive texlive-science texlive-xetex ghostscript pdf2svg texlive-fonts-extra sagemath python3-pip
 
       - name: Install poetry 1.8.4
         run: |
-          python -m ensurepip
           python -m pip install --upgrade pip
           python -m pip install poetry==1.8.4
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -107,10 +107,13 @@ jobs:
       - name: View poetry --help
         run: poetry --help
 
+      - name: Install build dependencies if on Linux
+        if: runner.os == 'Linux'
+        run: sudo apt-get -y install libcairo2-dev pkg-config python3-dev
+
       - name: Install dependencies
         shell: bash
         run: |
-          sudo apt-get -y install libcairo2-dev pkg-config python3-dev
           python -m poetry install --all-extras
           python -m poetry run python scripts/fetch_core.py
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
 
   deep-test:
     needs: format-and-types
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: oscarlevin/pretext:full
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,7 +75,7 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         poetry-version: ["1.8.4"]
-        os: [ubuntu-22.04, windows-latest]
+        os: [ubuntu-latest, windows-latest]
         exclude:
           - os: windows-latest
             python-version: "3.8"
@@ -85,7 +85,7 @@ jobs:
             python-version: "3.10"
           - os: windows-latest
             python-version: "3.11"
-          - os: ubuntu-22.04
+          - os: ubuntu-latest
             python-version: "3.12"
 
     runs-on: ${{ matrix.os }}
@@ -110,6 +110,7 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
+          sudo apt-get -y install libcairo2-dev pkg-config python3-dev
           python -m poetry install --all-extras
           python -m poetry run python scripts/fetch_core.py
 
@@ -123,7 +124,7 @@ jobs:
         run: |
           python -m poetry run pytest -v --cov
 
-          
+
   schema:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,13 +34,18 @@ jobs:
   deep-test:
     needs: format-and-types
     runs-on: ubuntu-22.04
-    container: oscarlevin/pretext:full
+    #container: oscarlevin/pretext:full
 
     steps:
       - uses: actions/checkout@v3
 
       - name: Report Python version
         run: python --version
+
+      - name: Install apt packages (Linux with python 3.12 only)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends texlive texlive-science texlive-xetex ghostscript pdf2svg texlive-fonts-extra sagemath
 
       - name: Install poetry 1.8.4
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,14 +31,51 @@ jobs:
       - name: Check types
         run: python -m poetry run mypy --install-types --non-interactive
 
-  tests:
+  deep-test:
+    needs: format-and-types
+    runs-on: ubuntu-latest
+    container: oscarlevin/pretext:full
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Report Python version
+        run: python --version
+
+      - name: Install poetry 1.8.4
+        run: |
+          python -m ensurepip
+          python -m pip install --upgrade pip
+          python -m pip install poetry==1.8.4
+
+      - name: View poetry --help
+        run: poetry --help
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          python -m poetry install --all-extras
+          python -m poetry run python scripts/fetch_core.py
+
+      - name: Ensure dependencies are present
+        run: |
+          echo "manually installing pelican; poetry does not seem to do this correctly."
+          python -m poetry run pip install pelican
+          python -m poetry run pelican --version
+
+      - name: Test with pytest
+        run: |
+          python -m poetry run pytest -v --cov
+
+
+  broad-tests:
     needs: format-and-types
     strategy:
       fail-fast: true
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         poetry-version: ["1.8.4"]
-        os: [ubuntu-22.04, windows-latest]
+        os: [ubuntu-latest, windows-latest]
         exclude:
           - os: windows-latest
             python-version: "3.8"
@@ -48,6 +85,8 @@ jobs:
             python-version: "3.10"
           - os: windows-latest
             python-version: "3.11"
+          - os: ubuntu-latest
+            python-version: "3.12"
 
     runs-on: ${{ matrix.os }}
 
@@ -58,13 +97,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Install apt packages (Linux with python 3.12 only)
-        if: runner.os == 'Linux' && matrix.python-version == '3.12'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends texlive texlive-science texlive-xetex ghostscript pdf2svg texlive-fonts-extra sagemath
-
 
       - name: Install poetry ${{ matrix.poetry-version }}
         run: |
@@ -91,6 +123,7 @@ jobs:
         run: |
           python -m poetry run pytest -v --cov
 
+          
   schema:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,7 +75,7 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         poetry-version: ["1.8.4"]
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-22.04, windows-latest]
         exclude:
           - os: windows-latest
             python-version: "3.8"
@@ -85,7 +85,7 @@ jobs:
             python-version: "3.10"
           - os: windows-latest
             python-version: "3.11"
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             python-version: "3.12"
 
     runs-on: ${{ matrix.os }}

--- a/poetry.lock
+++ b/poetry.lock
@@ -2148,26 +2148,26 @@ reference = "pypi-public"
 
 [[package]]
 name = "pycairo"
-version = "1.26.0"
+version = "1.26.1"
 description = "Python interface for cairo"
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "pycairo-1.26.0-cp310-cp310-win32.whl", hash = "sha256:696ba8024d2827e66e088a6e05a3b0aea30d289476bcb2ca47c9670d40900a50"},
-    {file = "pycairo-1.26.0-cp310-cp310-win_amd64.whl", hash = "sha256:b6690a00fb225c19f42d76660e676aba7ae7cb18f3632cb02bce7f0d9b9c3800"},
-    {file = "pycairo-1.26.0-cp310-cp310-win_arm64.whl", hash = "sha256:1d54e28170a5e790269d9db4c195cca5152ff018ba7e330d0ed05d86ccc2ea7d"},
-    {file = "pycairo-1.26.0-cp311-cp311-win32.whl", hash = "sha256:5986b8da3e7de7ab931d7ad527938df38f75d3a3bdea2b515c786c5ca2c5093c"},
-    {file = "pycairo-1.26.0-cp311-cp311-win_amd64.whl", hash = "sha256:d374d9ec6d2f791bf57105d87a9028db1ef2b687848f64a524e447033eae7229"},
-    {file = "pycairo-1.26.0-cp311-cp311-win_arm64.whl", hash = "sha256:20a31af89d92ffd5fc60c08e65ff649f16e18621a14a40dbdb049fc74942d7a9"},
-    {file = "pycairo-1.26.0-cp312-cp312-win32.whl", hash = "sha256:d63929ab5a2f890a333f2f2f51de9f1c9fe20d1bddc982c2ca577b737448d72f"},
-    {file = "pycairo-1.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:8616408ae93de4824a3777ec532ea75643e4bf74e49d601062c0b1788180c962"},
-    {file = "pycairo-1.26.0-cp312-cp312-win_arm64.whl", hash = "sha256:a611e4d82ad8470138bb46d465d47e8db826d9d80b6a520ccd83ee007f2073e4"},
-    {file = "pycairo-1.26.0-cp38-cp38-win32.whl", hash = "sha256:675578bc6d62d15ff8669f264783efc9c8c73e3a6f564b294a70fb45a2f78667"},
-    {file = "pycairo-1.26.0-cp38-cp38-win_amd64.whl", hash = "sha256:aac447b423b33b64119ecdd1ffebf9163b07f5401c5da50c707197efdd1c918a"},
-    {file = "pycairo-1.26.0-cp39-cp39-win32.whl", hash = "sha256:9fa51168010e2dfb45499df071fca2d921893f724646f3454951000a7ad0cabb"},
-    {file = "pycairo-1.26.0-cp39-cp39-win_amd64.whl", hash = "sha256:3e4e18ea03122e60abe3eb611e2849859cc950083ff85d8369328eadf3df63f5"},
-    {file = "pycairo-1.26.0-cp39-cp39-win_arm64.whl", hash = "sha256:a8f3b567ba2ad55624a809823ccf75aff8d768c20216cb5888365f6fc695c1d2"},
-    {file = "pycairo-1.26.0.tar.gz", hash = "sha256:2dddd0a874fbddb21e14acd9b955881ee1dc6e63b9c549a192d613a907f9cbeb"},
+    {file = "pycairo-1.26.1-cp310-cp310-win32.whl", hash = "sha256:b93b9e3072826a346f1f79cb1becc403d1ba4a3971cad61d144db0fe6dcb6be8"},
+    {file = "pycairo-1.26.1-cp310-cp310-win_amd64.whl", hash = "sha256:acfc76924ed668d8fea50f6cc6097b9a57ef6cd3dc3f2fa20814380d639a6dd2"},
+    {file = "pycairo-1.26.1-cp310-cp310-win_arm64.whl", hash = "sha256:067191315c3b4d09cad1ec57cdb8fc1d72e2574e89389c268a94f22d4fa98b5f"},
+    {file = "pycairo-1.26.1-cp311-cp311-win32.whl", hash = "sha256:56a29623aa7b4adbde5024c61ff001455b5a3def79e512742ea45ab36c3fe24b"},
+    {file = "pycairo-1.26.1-cp311-cp311-win_amd64.whl", hash = "sha256:8d2889e03a095de5da9e68a589b691a3ada09d60ef18b5fc1b1b99f2a7794297"},
+    {file = "pycairo-1.26.1-cp311-cp311-win_arm64.whl", hash = "sha256:7a307111de345304ed8eadd7f81ebd7fb1fc711224aa314a4e8e33af7dfa3d27"},
+    {file = "pycairo-1.26.1-cp312-cp312-win32.whl", hash = "sha256:5cc1808e9e30ccd0f4d84ba7700db5aab5673f8b6b901760369ebb88a0823436"},
+    {file = "pycairo-1.26.1-cp312-cp312-win_amd64.whl", hash = "sha256:36131a726f568b2dbc5e78ff50fbaa379e69db00614d46d66b1e4289caf9b1ce"},
+    {file = "pycairo-1.26.1-cp312-cp312-win_arm64.whl", hash = "sha256:5577b51543ea4c283c15f436d891e9eaf6fd43fe74882adb032fba2c271f3fe9"},
+    {file = "pycairo-1.26.1-cp38-cp38-win32.whl", hash = "sha256:27ec7b42c58af35dc11352881262dce4254378b0f11be0959d1c13edb4539d2c"},
+    {file = "pycairo-1.26.1-cp38-cp38-win_amd64.whl", hash = "sha256:27357994d277b3fd10a45e9ef58f80a4cb5e3291fe76c5edd58d2d06335eb8e7"},
+    {file = "pycairo-1.26.1-cp39-cp39-win32.whl", hash = "sha256:e68300d1c2196d1d34de3432885ae9ff78e10426fa16f765742a11c6f8fe0a71"},
+    {file = "pycairo-1.26.1-cp39-cp39-win_amd64.whl", hash = "sha256:ce049930e294c29b53c68dcaab3df97cc5de7eb1d3d8e8a9f5c77e7164cd6e85"},
+    {file = "pycairo-1.26.1-cp39-cp39-win_arm64.whl", hash = "sha256:22e1db531d4ed3167a98f0ea165bfa2a30df9d6eb22361c38158c031065999a4"},
+    {file = "pycairo-1.26.1.tar.gz", hash = "sha256:a11b999ce55b798dbf13516ab038e0ce8b6ec299b208d7c4e767a6f7e68e8430"},
 ]
 
 [package.source]
@@ -3691,9 +3691,9 @@ reference = "pypi-public"
 
 [extras]
 homepage = ["pelican"]
-prefigure = ["prefig", "pycairo", "pycairo"]
+prefigure = ["prefig"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.5"
-content-hash = "e155b7400bc04dd1dddb9d90064998c80ce619ff6dde1ac07ab119b9d9294725"
+content-hash = "5b28c72393dfd4cd7aeeca918882ed4cc7fda2c5f9ee8a735d82f50df7cd0897"

--- a/poetry.lock
+++ b/poetry.lock
@@ -20,6 +20,33 @@ url = "https://pypi.org/simple"
 reference = "pypi-public"
 
 [[package]]
+name = "anyio"
+version = "4.5.2"
+description = "High level compatibility layer for multiple asynchronous event loop implementations"
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "anyio-4.5.2-py3-none-any.whl", hash = "sha256:c011ee36bc1e8ba40e5a81cb9df91925c218fe9b778554e0b56a21e1b5d4716f"},
+    {file = "anyio-4.5.2.tar.gz", hash = "sha256:23009af4ed04ce05991845451e11ef02fc7c5ed29179ac9a420e5ad0ac7ddc5b"},
+]
+
+[package.dependencies]
+exceptiongroup = {version = ">=1.0.2", markers = "python_version < \"3.11\""}
+idna = ">=2.8"
+sniffio = ">=1.1"
+typing-extensions = {version = ">=4.1", markers = "python_version < \"3.11\""}
+
+[package.extras]
+doc = ["Sphinx (>=7.4,<8.0)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme"]
+test = ["anyio[trio]", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypothesis (>=4.0)", "psutil (>=5.9)", "pytest (>=7.0)", "pytest-mock (>=3.6.1)", "trustme", "truststore (>=0.9.1)", "uvloop (>=0.21.0b1)"]
+trio = ["trio (>=0.26.1)"]
+
+[package.source]
+type = "legacy"
+url = "https://pypi.org/simple"
+reference = "pypi-public"
+
+[[package]]
 name = "autocommand"
 version = "2.2.2"
 description = "A library to create a command-line program from a function"
@@ -2149,31 +2176,6 @@ url = "https://pypi.org/simple"
 reference = "pypi-public"
 
 [[package]]
-name = "pycairo"
-version = "1.27.0"
-description = "Python interface for cairo"
-optional = true
-python-versions = ">=3.9"
-files = [
-    {file = "pycairo-1.27.0-cp310-cp310-win32.whl", hash = "sha256:e20f431244634cf244ab6b4c3a2e540e65746eed1324573cf291981c3e65fc05"},
-    {file = "pycairo-1.27.0-cp310-cp310-win_amd64.whl", hash = "sha256:03bf570e3919901572987bc69237b648fe0de242439980be3e606b396e3318c9"},
-    {file = "pycairo-1.27.0-cp311-cp311-win32.whl", hash = "sha256:9a9b79f92a434dae65c34c830bb9abdbd92654195e73d52663cbe45af1ad14b2"},
-    {file = "pycairo-1.27.0-cp311-cp311-win_amd64.whl", hash = "sha256:d40a6d80b15dacb3672dc454df4bc4ab3988c6b3f36353b24a255dc59a1c8aea"},
-    {file = "pycairo-1.27.0-cp312-cp312-win32.whl", hash = "sha256:e2239b9bb6c05edae5f3be97128e85147a155465e644f4d98ea0ceac7afc04ee"},
-    {file = "pycairo-1.27.0-cp312-cp312-win_amd64.whl", hash = "sha256:27cb4d3a80e3b9990af552818515a8e466e0317063a6e61585533f1a86f1b7d5"},
-    {file = "pycairo-1.27.0-cp313-cp313-win32.whl", hash = "sha256:01505c138a313df2469f812405963532fc2511fb9bca9bdc8e0ab94c55d1ced8"},
-    {file = "pycairo-1.27.0-cp313-cp313-win_amd64.whl", hash = "sha256:b0349d744c068b6644ae23da6ada111c8a8a7e323b56cbce3707cba5bdb474cc"},
-    {file = "pycairo-1.27.0-cp39-cp39-win32.whl", hash = "sha256:f9ca8430751f1fdcd3f072377560c9e15608b9a42d61375469db853566993c9b"},
-    {file = "pycairo-1.27.0-cp39-cp39-win_amd64.whl", hash = "sha256:1b1321652a6e27c4de3069709b1cae22aed2707fd8c5e889c04a95669228af2a"},
-    {file = "pycairo-1.27.0.tar.gz", hash = "sha256:5cb21e7a00a2afcafea7f14390235be33497a2cce53a98a19389492a60628430"},
-]
-
-[package.source]
-type = "legacy"
-url = "https://pypi.org/simple"
-reference = "pypi-public"
-
-[[package]]
 name = "pycodestyle"
 version = "2.11.1"
 description = "Python style guide checker"
@@ -3131,6 +3133,22 @@ url = "https://pypi.org/simple"
 reference = "pypi-public"
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+description = "Sniff out which async library your code is running under"
+optional = true
+python-versions = ">=3.7"
+files = [
+    {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
+    {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
+]
+
+[package.source]
+type = "legacy"
+url = "https://pypi.org/simple"
+reference = "pypi-public"
+
+[[package]]
 name = "strictyaml"
 version = "1.7.3"
 description = "Strict, typed YAML parser"
@@ -3335,13 +3353,19 @@ reference = "pypi-public"
 [[package]]
 name = "urllib3"
 version = "2.2.3"
-description = ""
+description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = "*"
+python-versions = ">=3.8"
 files = [
     {file = "urllib3-2.2.3-py3-none-any.whl", hash = "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac"},
     {file = "urllib3-2.2.3.tar.gz", hash = "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9"},
 ]
+
+[package.extras]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
+h2 = ["h2 (>=4,<5)"]
+socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
+zstd = ["zstandard (>=0.18.0)"]
 
 [package.source]
 type = "legacy"
@@ -3403,9 +3427,9 @@ reference = "pypi-public"
 [[package]]
 name = "watchfiles"
 version = "0.24.0"
-description = ""
+description = "Simple, modern and high performance file watching and code reload in python."
 optional = true
-python-versions = "*"
+python-versions = ">=3.8"
 files = [
     {file = "watchfiles-0.24.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:083dc77dbdeef09fa44bb0f4d1df571d2e12d8a8f985dccde71ac3ac9ac067a0"},
     {file = "watchfiles-0.24.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e94e98c7cb94cfa6e071d401ea3342767f28eb5a06a58fafdc0d2a4974f4f35c"},
@@ -3491,6 +3515,9 @@ files = [
     {file = "watchfiles-0.24.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49fb58bcaa343fedc6a9e91f90195b20ccb3135447dc9e4e2570c3a39565853e"},
     {file = "watchfiles-0.24.0.tar.gz", hash = "sha256:afb72325b74fa7a428c009c1b8be4b4d7c2afedafb2982827ef2156646df2fe1"},
 ]
+
+[package.dependencies]
+anyio = ">=3.0.0"
 
 [package.source]
 type = "legacy"
@@ -3669,4 +3696,4 @@ prefigure = ["prefig", "pycairo", "pycairo"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.5"
-content-hash = "7d5491bc7e137c3d8b5be051dc79f1316cea7ffa473086cb16c4a4c5348615ef"
+content-hash = "e155b7400bc04dd1dddb9d90064998c80ce619ff6dde1ac07ab119b9d9294725"

--- a/poetry.lock
+++ b/poetry.lock
@@ -20,33 +20,6 @@ url = "https://pypi.org/simple"
 reference = "pypi-public"
 
 [[package]]
-name = "anyio"
-version = "4.5.2"
-description = "High level compatibility layer for multiple asynchronous event loop implementations"
-optional = true
-python-versions = ">=3.8"
-files = [
-    {file = "anyio-4.5.2-py3-none-any.whl", hash = "sha256:c011ee36bc1e8ba40e5a81cb9df91925c218fe9b778554e0b56a21e1b5d4716f"},
-    {file = "anyio-4.5.2.tar.gz", hash = "sha256:23009af4ed04ce05991845451e11ef02fc7c5ed29179ac9a420e5ad0ac7ddc5b"},
-]
-
-[package.dependencies]
-exceptiongroup = {version = ">=1.0.2", markers = "python_version < \"3.11\""}
-idna = ">=2.8"
-sniffio = ">=1.1"
-typing-extensions = {version = ">=4.1", markers = "python_version < \"3.11\""}
-
-[package.extras]
-doc = ["Sphinx (>=7.4,<8.0)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme"]
-test = ["anyio[trio]", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypothesis (>=4.0)", "psutil (>=5.9)", "pytest (>=7.0)", "pytest-mock (>=3.6.1)", "trustme", "truststore (>=0.9.1)", "uvloop (>=0.21.0b1)"]
-trio = ["trio (>=0.26.1)"]
-
-[package.source]
-type = "legacy"
-url = "https://pypi.org/simple"
-reference = "pypi-public"
-
-[[package]]
 name = "autocommand"
 version = "2.2.2"
 description = "A library to create a command-line program from a function"
@@ -3133,22 +3106,6 @@ url = "https://pypi.org/simple"
 reference = "pypi-public"
 
 [[package]]
-name = "sniffio"
-version = "1.3.1"
-description = "Sniff out which async library your code is running under"
-optional = true
-python-versions = ">=3.7"
-files = [
-    {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
-    {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
-]
-
-[package.source]
-type = "legacy"
-url = "https://pypi.org/simple"
-reference = "pypi-public"
-
-[[package]]
 name = "strictyaml"
 version = "1.7.3"
 description = "Strict, typed YAML parser"
@@ -3353,19 +3310,13 @@ reference = "pypi-public"
 [[package]]
 name = "urllib3"
 version = "2.2.3"
-description = "HTTP library with thread-safe connection pooling, file post, and more."
+description = ""
 optional = false
-python-versions = ">=3.8"
+python-versions = "*"
 files = [
     {file = "urllib3-2.2.3-py3-none-any.whl", hash = "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac"},
     {file = "urllib3-2.2.3.tar.gz", hash = "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9"},
 ]
-
-[package.extras]
-brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
-h2 = ["h2 (>=4,<5)"]
-socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
-zstd = ["zstandard (>=0.18.0)"]
 
 [package.source]
 type = "legacy"
@@ -3427,9 +3378,9 @@ reference = "pypi-public"
 [[package]]
 name = "watchfiles"
 version = "0.24.0"
-description = "Simple, modern and high performance file watching and code reload in python."
+description = ""
 optional = true
-python-versions = ">=3.8"
+python-versions = "*"
 files = [
     {file = "watchfiles-0.24.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:083dc77dbdeef09fa44bb0f4d1df571d2e12d8a8f985dccde71ac3ac9ac067a0"},
     {file = "watchfiles-0.24.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e94e98c7cb94cfa6e071d401ea3342767f28eb5a06a58fafdc0d2a4974f4f35c"},
@@ -3515,9 +3466,6 @@ files = [
     {file = "watchfiles-0.24.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49fb58bcaa343fedc6a9e91f90195b20ccb3135447dc9e4e2570c3a39565853e"},
     {file = "watchfiles-0.24.0.tar.gz", hash = "sha256:afb72325b74fa7a428c009c1b8be4b4d7c2afedafb2982827ef2156646df2fe1"},
 ]
-
-[package.dependencies]
-anyio = ">=3.0.0"
 
 [package.source]
 type = "legacy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ plastex = "^3"
 jinja2 = "^3"
 pelican = { extras = ["markdown"], version = "^4.10", optional = true }
 prefig = { extras = ["pycairo"], version = "^0.2.10", optional = true }
-pycairo = [{version = ">=1.20, <=1.26", python = "3.8", optional = true}, {version = "^1.20", python = ">=3.9", optional = true}]
+pycairo = [{version = ">=1.20, <=1.26", python = "3.8", optional = true}, {version = ">=1.20, <=1.26", python = ">=3.9", optional = true}]
 
 # Development dependencies
 # ------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ plastex = "^3"
 jinja2 = "^3"
 pelican = { extras = ["markdown"], version = "^4.10", optional = true }
 prefig = { extras = ["pycairo"], version = "^0.2.10", optional = true }
-pycairo = [{version = ">=1.20, <=1.26", python = "3.8", optional = true}, {version = ">=1.20, <=1.26", python = ">=3.9", optional = true}]
+
 
 # Development dependencies
 # ------------------------
@@ -69,7 +69,7 @@ pep8-naming = "^0.14.1"
 
 [tool.poetry.extras]
 homepage = ["pelican"]
-prefigure = ["prefig", "pycairo"]
+prefigure = ["prefig"]
 
 [tool.poetry.scripts]
 pretext = 'pretext.cli:main'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -223,7 +223,7 @@ def test_custom_xsl(tmp_path: Path, script_runner: ScriptRunner) -> None:
     assert (custom_path / "output" / "test2").exists()
 
 
-#@pytest.mark.skip(reason="secondary webwork server not currently available")
+# @pytest.mark.skip(reason="secondary webwork server not currently available")
 def test_custom_webwork_server(tmp_path: Path, script_runner: ScriptRunner) -> None:
     custom_path = tmp_path / "custom"
     shutil.copytree(EXAMPLES_DIR / "projects" / "custom-wwserver", custom_path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -223,7 +223,7 @@ def test_custom_xsl(tmp_path: Path, script_runner: ScriptRunner) -> None:
     assert (custom_path / "output" / "test2").exists()
 
 
-@pytest.mark.skip(reason="secondary webwork server not currently available")
+#@pytest.mark.skip(reason="secondary webwork server not currently available")
 def test_custom_webwork_server(tmp_path: Path, script_runner: ScriptRunner) -> None:
     custom_path = tmp_path / "custom"
     shutil.copytree(EXAMPLES_DIR / "projects" / "custom-wwserver", custom_path)


### PR DESCRIPTION
This pulls out the full test (using latex and sage and also doing the sample article) into a separate test that will run inside the oscarlevin/pretext:full container.  That also serves as the test for ubuntu and python 3.12.  