### PR TITLE
Require node version check for cssbuilder npm install

### DIFF
--- a/pretext/utils.py
+++ b/pretext/utils.py
@@ -529,7 +529,7 @@ def ensure_css(xml: Path, pub_file: str, stringparams: t.Dict[str, str]) -> None
             "Attempting to install/update required node packages to generate css from sass."
         )
         try:
-            subprocess.run("npm install", shell=True)
+            subprocess.run("npm install --engine-strict=true", shell=True)
         except Exception as e:
             log.critical(
                 "Unable to install required npm packages to build css files.  To use your selected HTML theme, you must have node.js and npm installed."


### PR DESCRIPTION
In https://github.com/PreTeXtBook/pretext/pull/2371, a minimum node version (14) is being listed in the cssbuilder package.json. npm won't actually obey that unless invoked with `--engine-strict=true`.

If there is no engine requirement in the package.json, the flag does nothing, so there shouldn't be any issues with using it with an old version of PreTeXt.