### PR TITLE
separate cache into folders by asset type

### DIFF
--- a/pretext/project/__init__.py
+++ b/pretext/project/__init__.py
@@ -827,9 +827,12 @@ class Target(pxml.BaseXmlModel, tag="target", search_mode=SearchMode.UNORDERED):
         if clean:
             self.clean_assets()
 
-        # Ensure that the generated_cache directory exists:
-        if not self.generated_cache_abspath().exists():
-            self.generated_cache_abspath().mkdir(parents=True, exist_ok=True)
+        # Ensure that the generated_cache directories exist:
+        for subdir in ["latex-image", "asymptote", "sageplot"]:
+            if not (self.generated_cache_abspath() / subdir).exists():
+                (self.generated_cache_abspath() / subdir).mkdir(
+                    parents=True, exist_ok=True
+                )
         log.debug(
             f"Using cached assets in {self.generated_cache_abspath()} where possible."
         )

--- a/pretext/project/generate.py
+++ b/pretext/project/generate.py
@@ -135,8 +135,6 @@ def cache_asset_filename(
     hash = hashlib.md5()
     # hash the asset file
     hash.update(asset_content)
-    # include the asset_type in hash
-    hash.update(asset_type.encode())
     asset_hash = hash.hexdigest()
     # create the cache file name
-    return cache_dir / f"{asset_hash}.{extension}"
+    return cache_dir / asset_type / f"{asset_hash}.{extension}"

--- a/pretext/project/generate.py
+++ b/pretext/project/generate.py
@@ -99,7 +99,7 @@ def individual_latex_image(
     asset_file = Path(latex_image).resolve()
     outformats = ["png", "pdf", "svg", "eps"] if outformat == "all" else [outformat]
     cache_files = {
-        ext: cache_asset_filename(asset_file, ext, "latex_image", cache_dir)
+        ext: cache_asset_filename(asset_file, ext, "latex-image", cache_dir)
         for ext in outformats
     }
     output_files = {


### PR DESCRIPTION
As suggested by @StevenClontz.  This also makes it clear what the contents of `.cache` is in case a user gets curious.