### PR TITLE
Success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Instructions: Add a subsection under `[Unreleased]` for additions, fixes, change
 
 - Dynamic substitution xml file was not generated on html build correctly; it is now.
 
+### Changed
+
+- Improved success feedback message.
+
 ## [2.14.0] - 2025-02-26
 
 Includes updates to core through commit: [8f8858c](https://github.com/PreTeXtBook/pretext/commit/8f8858c9deaeeb1057c365aeaca52652abb496bd)

--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -596,7 +596,10 @@ def build(
             t.build(
                 clean=clean, generate=not no_generate, xmlid=xmlid, no_knowls=no_knowls
             )
-        log.info("\nSuccess! Run `pretext view` to see the results.\n")
+            if t.format == "html":
+                log.info(f"\nSuccess! Run `pretext view {t.name}` to see the results.\n")
+            else:
+                log.info(f"\nSuccess! The output is in {t.output_dir_abspath()}.\n")
     except ValidationError as e:
         # A validation error at this point must be because the publication file is invalid, which only happens if the /source/directories/@generated|@external attributes are missing.
         log.critical(

--- a/pretext/cli.py
+++ b/pretext/cli.py
@@ -597,7 +597,9 @@ def build(
                 clean=clean, generate=not no_generate, xmlid=xmlid, no_knowls=no_knowls
             )
             if t.format == "html":
-                log.info(f"\nSuccess! Run `pretext view {t.name}` to see the results.\n")
+                log.info(
+                    f"\nSuccess! Run `pretext view {t.name}` to see the results.\n"
+                )
             else:
                 log.info(f"\nSuccess! The output is in {t.output_dir_abspath()}.\n")
     except ValidationError as e:


### PR DESCRIPTION
This improves the Success! message at the end of a successful build.  If html format, it instructs you to `pretext view [target name]`; otherwise it tells you where the output is.