### PR TITLE
added prefigure as an asset for revealjs format

### DIFF
--- a/pretext/constants.py
+++ b/pretext/constants.py
@@ -205,7 +205,7 @@ ASSET_FORMATS: t.Dict[str, t.Dict[str, t.List[str]]] = {
         "asymptote": ["html"],
         "latex-image": ["svg"],
         "sageplot": ["html", "svg"],
-        "prefigure": ["svg"]
+        "prefigure": ["svg"],
     },
     "webwork": {
         "asymptote": [],

--- a/pretext/constants.py
+++ b/pretext/constants.py
@@ -205,6 +205,7 @@ ASSET_FORMATS: t.Dict[str, t.Dict[str, t.List[str]]] = {
         "asymptote": ["html"],
         "latex-image": ["svg"],
         "sageplot": ["html", "svg"],
+        "prefigure": ["svg"]
     },
     "webwork": {
         "asymptote": [],


### PR DESCRIPTION
This change enables PreFigure diagrams to be included in slideshows with the revealjs format.