### PR TITLE
fix MOM download bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Instructions: Add a subsection under `[Unreleased]` for additions, fixes, change
 
 ### Fixed
 
+- Bug that caused MyOpenMath problems to be downloaded on every build, regardless of whether they were needed.
 - Bug which caused error in `pretext view` when the `running_servers` file contained a blank line.
 
 ## [2.20.0] - 2025-06-20

--- a/pretext/project/__init__.py
+++ b/pretext/project/__init__.py
@@ -547,8 +547,9 @@ class Target(pxml.BaseXmlModel, tag="target", search_mode=SearchMode.UNORDERED):
 
             for prob_num in mom_prob_nums:
                 assert isinstance(prob_num, str)
+                log.debug(f"Checking for MyOpenMath problem {prob_num}")
                 if not (
-                    self.generated_dir_abspath() / "problems" / f"{prob_num}.xml"
+                    self.generated_dir_abspath() / "problems" / f"mom-{prob_num}.xml"
                 ).exists():
                     log.debug(
                         f"MyOpenMath problem {prob_num} does not exist, generating"
@@ -556,8 +557,8 @@ class Target(pxml.BaseXmlModel, tag="target", search_mode=SearchMode.UNORDERED):
                     self.generate_assets(
                         requested_asset_types=["myopenmath"], only_changed=False
                     )
-                # Only need to generate once a single missing file is discovered.
-                break
+                    # Only need to generate once a single missing file is discovered.
+                    break
         else:
             log.debug("Source does not contain myopenmath problems")
 


### PR DESCRIPTION
My Open Math problems need to be downloaded, as their xml files are assumed to exist for other generate/build steps.  Previously, we checked whether a file like `problems/2375.xml` existed, but that should have been `problems/mom-2375.xml`.

Luckily, the code contained another bug that would have caused an issue if any file after the first was needed.