### PR TITLE
FITB: Dynamic substitutions require node modules be installed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Instructions: Add a subsection under `[Unreleased]` for additions, fixes, change
 
 ## [Unreleased]
 
+### Changed
+
+- Generating dynamic substitutions now uses node instead of playwright.  Node 22.10 or greater is required.
+
 ## [2.22.0] - 2025-07-05
 
 Includes updates to core through commit: [e6f9288](https://github.com/PreTeXtBook/pretext/commit/e6f92889e1e4978f71d7417be410ca379d6e9eff)

--- a/pretext/__init__.py
+++ b/pretext/__init__.py
@@ -19,7 +19,7 @@ from single_version import get_version
 VERSION = get_version("pretext", Path(__file__).parent.parent)
 
 
-CORE_COMMIT = "e6f92889e1e4978f71d7417be410ca379d6e9eff"
+CORE_COMMIT = "75e5bb36da237e2ddb11bec9454c8981c0d4897c"
 
 
 def activate() -> None:

--- a/pretext/constants.py
+++ b/pretext/constants.py
@@ -26,6 +26,7 @@ ASSETS_BY_FORMAT = {
         "codelens",
         "datafile",
         "myopenmath",
+        "dynamic-subs",
     ],
     "pdf": [
         "webwork",

--- a/pretext/project/__init__.py
+++ b/pretext/project/__init__.py
@@ -995,6 +995,7 @@ class Target(pxml.BaseXmlModel, tag="target", search_mode=SearchMode.UNORDERED):
         # The dynamic-subs asset output is required for the subsequent asset generation, so needs to be near the top.
         if "dynamic-subs" in assets_to_generate:
             try:
+                utils.ensure_dynsub_node_modules()
                 core.dynamic_substitutions(
                     xml_source=self.source_abspath(),
                     pub_file=self.publication_abspath().as_posix(),

--- a/pretext/resources/__init__.py
+++ b/pretext/resources/__init__.py
@@ -85,7 +85,9 @@ def install(reinstall: bool = False, npm_install: bool = False) -> None:
                 raise FileNotFoundError
             subprocess.run([npm_cmd, "install"])
         except Exception as e:
-            log.warning(f"Unable to install npm packages for dynamic substitutions: {e}")
+            log.warning(
+                f"Unable to install npm packages for dynamic substitutions: {e}"
+            )
             log.debug(e, exc_info=True)
             return
 

--- a/pretext/resources/__init__.py
+++ b/pretext/resources/__init__.py
@@ -74,6 +74,20 @@ def install(reinstall: bool = False, npm_install: bool = False) -> None:
             log.warning(f"Unable to install npm packages for theme building: {e}")
             log.debug(e, exc_info=True)
             return
+        # Dynamic substitution script requires node versions > 22.10
+        os.chdir(_RESOURCE_BASE_PATH / "core" / "script" / "dynsub")
+        try:
+            npm_cmd = shutil.which("npm")
+            if npm_cmd is None:
+                log.warning(
+                    "Cannot find npm. Will not be able to extract dynamic substitutions."
+                )
+                raise FileNotFoundError
+            subprocess.run([npm_cmd, "install"])
+        except Exception as e:
+            log.warning(f"Unable to install npm packages for dynamic substitutions: {e}")
+            log.debug(e, exc_info=True)
+            return
 
 
 def resource_base_path() -> Path:

--- a/pretext/utils.py
+++ b/pretext/utils.py
@@ -569,7 +569,7 @@ def ensure_dynsub_node_modules() -> None:
             node_cmd = shutil.which("node")
             if node_cmd is None:
                 log.warning(
-                    "Node.js must be installed to extract dynamic substitutions.  Please install node.js and npm.\n Will try to use prebuilt CSS files instead."
+                    "Node.js must be installed to extract dynamic substitutions.  Please install node.js and npm."
                 )
                 raise FileNotFoundError
             node_version = subprocess.run([node_cmd, "-v"], capture_output=True)

--- a/pretext/utils.py
+++ b/pretext/utils.py
@@ -596,9 +596,7 @@ def ensure_dynsub_node_modules() -> None:
         try:
             npm_cmd = shutil.which("npm")
             if npm_cmd is None:
-                log.warning(
-                    "Cannot find npm. Install npm and try again."
-                )
+                log.warning("Cannot find npm. Install npm and try again.")
                 raise FileNotFoundError
             subprocess.run([npm_cmd, "install"])
         except Exception as e:


### PR DESCRIPTION
I believe that this captures the CLI requirements to match pretext PR #2577. Before the dynamic substitution extraction routine in  core can be called, we need to ensure that the associated node packages are installed. (In pretext/script/dynsub). Node can't load the dynamic JS libraries that Runestone components require for versions below 22.10, and which is required to generate the randomized content that is being extracted.

I made three key changes mimicking what was happening with themes (also require npm install), but don't know how to test them:

1. Update the install script to install script/dynsub node packages
2. Add a test routine (ensure_dynsub_node_packages) which tries to install if missing
3. Update the routine that calls core:dynamic_substitutions to call the test routine

I don't know of any other changes that would be required. This is more intended to point out what I understand would be needed, and I hope it is enough for you to understand if anything else is missing.