### PR TITLE
Cascade exceptions for node and npm for dynamic substitutions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,11 @@ jobs:
       - name: Report Python version
         run: python --version
 
+      - name: set up node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Install poetry
         run: |
           pip install --upgrade pip
@@ -83,13 +88,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
         os: [ubuntu-latest, windows-latest]
         exclude:
-          - os: windows-latest
-            python-version: "3.8"
-          - os: windows-latest
-            python-version: "3.9"
           - os: windows-latest
             python-version: "3.10"
           - os: windows-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Instructions: Add a subsection under `[Unreleased]` for additions, fixes, change
 
 ## [Unreleased]
 
+## [2.23.0] - 2025-07-11
+
+Includes updates to core through commit: [899648f](https://github.com/PreTeXtBook/pretext/commit/899648f16a2f78760b5d309c98c623d9c63f09e3)
+
 ### Added
 
 - Print preview for worksheets now has option to highlight workspace and compare the rendered workspace to the authored height.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Instructions: Add a subsection under `[Unreleased]` for additions, fixes, change
 
 ## [Unreleased]
 
+### Changed
+
+- Generating dynamic substitutions now uses node instead of playwright.  Node 22.10 or greater is required.
+
 ## [2.22.0] - 2025-07-05
 
 Includes updates to core through commit: [e6f9288](https://github.com/PreTeXtBook/pretext/commit/e6f92889e1e4978f71d7417be410ca379d6e9eff)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Instructions: Add a subsection under `[Unreleased]` for additions, fixes, change
 
 ## [Unreleased]
 
+### Added
+
+- Print preview for worksheets now has option to highlight workspace and compare the rendered workspace to the authored height.
+- WeBWorK exercises can be generated using a local copy of PG (with the proper setup).
+
 ### Changed
 
 - Generating dynamic substitutions now uses node instead of playwright.  Node 22.10 or greater is required.

--- a/pretext/__init__.py
+++ b/pretext/__init__.py
@@ -19,7 +19,7 @@ from single_version import get_version
 VERSION = get_version("pretext", Path(__file__).parent.parent)
 
 
-CORE_COMMIT = "8a30b87cc26f5282d1997a1cc90cbf3b6bbef348"
+CORE_COMMIT = "fb0b3365f6f14b2f0002a2fbb874a27d25454bd7"
 
 
 def activate() -> None:

--- a/pretext/__init__.py
+++ b/pretext/__init__.py
@@ -19,7 +19,7 @@ from single_version import get_version
 VERSION = get_version("pretext", Path(__file__).parent.parent)
 
 
-CORE_COMMIT = "75e5bb36da237e2ddb11bec9454c8981c0d4897c"
+CORE_COMMIT = "1800a65ef1c0107e4bc85e1b1b2bc8ac5724005f"
 
 
 def activate() -> None:

--- a/pretext/__init__.py
+++ b/pretext/__init__.py
@@ -19,7 +19,7 @@ from single_version import get_version
 VERSION = get_version("pretext", Path(__file__).parent.parent)
 
 
-CORE_COMMIT = "e6f92889e1e4978f71d7417be410ca379d6e9eff"
+CORE_COMMIT = "75e5bb36da237e2ddb11bec9454c8981c0d4897c"
 
 
 def activate() -> None:

--- a/pretext/__init__.py
+++ b/pretext/__init__.py
@@ -19,7 +19,7 @@ from single_version import get_version
 VERSION = get_version("pretext", Path(__file__).parent.parent)
 
 
-CORE_COMMIT = "fb0b3365f6f14b2f0002a2fbb874a27d25454bd7"
+CORE_COMMIT = "899648f16a2f78760b5d309c98c623d9c63f09e3"
 
 
 def activate() -> None:

--- a/pretext/__init__.py
+++ b/pretext/__init__.py
@@ -19,7 +19,7 @@ from single_version import get_version
 VERSION = get_version("pretext", Path(__file__).parent.parent)
 
 
-CORE_COMMIT = "1800a65ef1c0107e4bc85e1b1b2bc8ac5724005f"
+CORE_COMMIT = "8a30b87cc26f5282d1997a1cc90cbf3b6bbef348"
 
 
 def activate() -> None:

--- a/pretext/constants.py
+++ b/pretext/constants.py
@@ -26,6 +26,7 @@ ASSETS_BY_FORMAT = {
         "codelens",
         "datafile",
         "myopenmath",
+        "dynamic-subs",
     ],
     "pdf": [
         "webwork",

--- a/pretext/project/__init__.py
+++ b/pretext/project/__init__.py
@@ -995,6 +995,7 @@ class Target(pxml.BaseXmlModel, tag="target", search_mode=SearchMode.UNORDERED):
         # The dynamic-subs asset output is required for the subsequent asset generation, so needs to be near the top.
         if "dynamic-subs" in assets_to_generate:
             try:
+                utils.ensure_dynsub_node_modules()
                 core.dynamic_substitutions(
                     xml_source=self.source_abspath(),
                     pub_file=self.publication_abspath().as_posix(),

--- a/pretext/resources/__init__.py
+++ b/pretext/resources/__init__.py
@@ -74,6 +74,22 @@ def install(reinstall: bool = False, npm_install: bool = False) -> None:
             log.warning(f"Unable to install npm packages for theme building: {e}")
             log.debug(e, exc_info=True)
             return
+        # Dynamic substitution script requires node versions > 22.10
+        os.chdir(_RESOURCE_BASE_PATH / "core" / "script" / "dynsub")
+        try:
+            npm_cmd = shutil.which("npm")
+            if npm_cmd is None:
+                log.warning(
+                    "Cannot find npm. Will not be able to extract dynamic substitutions."
+                )
+                raise FileNotFoundError
+            subprocess.run([npm_cmd, "install"])
+        except Exception as e:
+            log.warning(
+                f"Unable to install npm packages for dynamic substitutions: {e}"
+            )
+            log.debug(e, exc_info=True)
+            return
 
 
 def resource_base_path() -> Path:

--- a/pretext/resources/resource_hash_table.json
+++ b/pretext/resources/resource_hash_table.json
@@ -312,5 +312,15 @@
     "pretext-deploy.yml": "522de4fdd3abac688aca008d7fc452d9921b767dc047957cdaceb1109a0f70bb",
     "installPandoc.sh": "3882abdb8709b241796e030db622cae4bdd616b40fc580c1706a1a9c976e603c",
     "installSage.sh": "9a4ed5e41a901adcde5fcd812a8567e8c9086052f2ea4ca419e381882156b4ce"
+  },
+  "2.23.0": {
+    "project.ptx": "12c65b6da21b818659e0bcbc68b59c320402c741c9952d84180f25794d94bd72",
+    "codechat_config.yaml": "9b86ea061f2e29ff23403bbee99637eb629835fc8706be94824a3b5a690cc762",
+    ".gitignore": "c2a0e8ccdabd0538c0edba4474b64b3f958d3dd2fea2836807e60ac66bd17c9c",
+    "devcontainer.json": "7688856a8ad5fe77104e5c39d21530af39da14909c5f8daeb9595876a3a60722",
+    "pretext-cli.yml": "3b10d23e7668f1e8fc0fbd744cd3bc5f55c2c3e7fbc71ec3bcbe4b02d7c42131",
+    "pretext-deploy.yml": "0d346a3b5d96059e5c5dce6b566d125a7b6ac25c4b8d68e1a445cca32712c453",
+    "installPandoc.sh": "e165f40e3f065e80c068e33c4666066c1f1f36936770b2d6f8c6fab2fc9b56f9",
+    "installSage.sh": "0fd082e41d271697cc62bc1913bc0d05acd36c4608c7c19f25d095c4af6dd6a5"
   }
 }

--- a/pretext/utils.py
+++ b/pretext/utils.py
@@ -577,14 +577,14 @@ def ensure_dynsub_node_modules() -> None:
             node_version_decode = node_version.stdout.decode().split(".")
             main_version = int(node_version_decode[0][1:])
             sub_version = int(node_version_decode[1])
-            if main_version < 22 | (main_version == 22 and sub_version < 10):
+            if main_version < 22 or (main_version == 22 and sub_version < 10):
                 log.warning(
                     "Node version must be at least 22.10 to extract dynamic substitutions.  Please update node.js and npm."
                 )
-                return
+                raise FileNotFoundError
         except Exception as e:
             log.debug(e)
-            log.debug("", exc_info=True)
+            raise e
         # Check if node_modules is already present:
         if Path("node_modules").exists():
             log.debug("Node modules already installed.")
@@ -604,7 +604,7 @@ def ensure_dynsub_node_modules() -> None:
                 "Unable to install npm packages. Unable to extract dynamic substitutions."
             )
             log.warning(e)
-            log.debug("", exc_info=True)
+            raise e
 
 
 def playwright_install() -> None:

--- a/pretext/utils.py
+++ b/pretext/utils.py
@@ -559,6 +559,54 @@ def ensure_css_node_modules() -> None:
             log.debug("", exc_info=True)
 
 
+def ensure_dynsub_node_modules() -> None:
+    # Look for node_modules and install if we can.
+    with working_directory(
+        resources.resource_base_path() / "core" / "script" / "dynsub"
+    ):
+        # Make sure node version is at least 22.10:
+        try:
+            node_cmd = shutil.which("node")
+            if node_cmd is None:
+                log.warning(
+                    "Node.js must be installed to extract dynamic substitutions.  Please install node.js and npm."
+                )
+                raise FileNotFoundError
+            node_version = subprocess.run([node_cmd, "-v"], capture_output=True)
+            log.debug(f"Node version: {node_version.stdout.decode()}")
+            node_version_decode = node_version.stdout.decode().split(".")
+            main_version = int(node_version_decode[0][1:])
+            sub_version = int(node_version_decode[1])
+            if main_version < 22 | (main_version == 22 and sub_version < 10):
+                log.warning(
+                    "Node version must be at least 22.10 to extract dynamic substitutions.  Please update node.js and npm."
+                )
+                return
+        except Exception as e:
+            log.debug(e)
+            log.debug("", exc_info=True)
+        # Check if node_modules is already present:
+        if Path("node_modules").exists():
+            log.debug("Node modules already installed.")
+            return
+        # If not, try to install them:
+        log.debug(
+            "Attempting to install/update required node packages extract dynamic susbstitutions."
+        )
+        try:
+            npm_cmd = shutil.which("npm")
+            if npm_cmd is None:
+                log.warning("Cannot find npm. Install npm and try again.")
+                raise FileNotFoundError
+            subprocess.run([npm_cmd, "install"])
+        except Exception as e:
+            log.warning(
+                "Unable to install npm packages. Unable to extract dynamic substitutions."
+            )
+            log.warning(e)
+            log.debug("", exc_info=True)
+
+
 def playwright_install() -> None:
     """
     Run `playwright install` to ensure that its required browsers and tools are available to it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@
 # ----------------
 [tool.poetry]
 name = "pretext"
-version = "2.22.1"
+version = "2.23.1"
 description = "A package to author, build, and deploy PreTeXt projects."
 readme = "README.md"
 homepage = "https://pretextbook.org"

--- a/templates/devcontainer.json
+++ b/templates/devcontainer.json
@@ -13,7 +13,7 @@
 //
 ///////////////////////////////////////////////////////////////
 {
-  "image": "oscarlevin/pretext-full",
+  "image": "oscarlevin/pretext-full", // uses latest image from https://hub.docker.com/r/oscarlevin/pretext-full/tags
   // If you don't need sagemath, you can use a smaller base image.  Comment out the line above and uncomment the line below to use a smaller image.
   // "image": "oscarlevin/pretext",
   "features": {"ghcr.io/devcontainers/features/github-cli": {}},


### PR DESCRIPTION
If node does not reach its minimum version (22.10.0), or if npm is not installed, `pretext generate dynamic-subs` will fail. The original PR just posted the warnings but did not terminate the attempts. This raises the exception again so that the routine calling ensure_dynsub_node_modules will not proceed if the necessary tools aren't available.

Also corrected a boolean operator from bitwise or (|) to logical or (or).

Note: I wasn't sure if the empty `log.debug` that is replaced by a `raise e` was necessary.