### PR TITLE
Include braille_format.py in list of bundled scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Instructions: Add a subsection under `[Unreleased]` for additions, fixes, change
 
 ## [Unreleased]
 
+### Fixed
+
+- Bug preventing braille building to work.
+
 ## [2.25.1] - 2025-08-01
 
 Includes updates to core through commit: [f15f9b9](https://github.com/PreTeXtBook/pretext/commit/f15f9b9fee75331d64d0fff4d757c479ef85fcb7)

--- a/pretext/__init__.py
+++ b/pretext/__init__.py
@@ -19,7 +19,7 @@ from single_version import get_version
 VERSION = get_version("pretext", Path(__file__).parent.parent)
 
 
-CORE_COMMIT = "f15f9b9fee75331d64d0fff4d757c479ef85fcb7"
+CORE_COMMIT = "f78029a26ab131d9114b9235f3b51686d5819eb6"
 
 
 def activate() -> None:

--- a/pretext/core/__init__.py
+++ b/pretext/core/__init__.py
@@ -2,8 +2,6 @@ try:
     from .pretext import *
     from . import pretext
 
-    # from .braille_format import *
-    # from . import braille_format
 except ImportError as e:
     raise ImportError(
         "Failed to import the core pretext.py file. Perhaps the file is unavailable? "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ authors = [
     "Steven Clontz <steven.clontz@gmail.com>",
 ]
 license = "GPL-3.0-or-later"
-include = ["pretext/core/pretext.py", "pretext/resources/*.zip", "pretext/resources/*.json"]
+include = ["pretext/core/pretext.py", "pretext/core/braille_format.py", "pretext/resources/*.zip", "pretext/resources/*.json"]
 
 # Dependencies
 # ------------


### PR DESCRIPTION
This is why braille would build when developing locally but not when deployed.

I probably should write a test for this.