### PR TITLE
Remove codechat mapping for runestone builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Instructions: Add a subsection under `[Unreleased]` for additions, fixes, change
 
 ## [Unreleased]
 
+### Changed
+
+- Runestone builds no longer try to generate codechat mapping (if you want to use codechat previews, use a non-runestone html build).
+
 ## [2.30.1] - 2025-11-10
 
 Includes updates to core through commit: [e406b5c](https://github.com/PreTeXtBook/pretext/commit/e406b5c742d50f7b75a78aa5eac75bb285ad35b1)

--- a/pretext/__init__.py
+++ b/pretext/__init__.py
@@ -19,7 +19,7 @@ from single_version import get_version
 VERSION = get_version("pretext", Path(__file__).parent.parent)
 
 
-CORE_COMMIT = "e406b5c742d50f7b75a78aa5eac75bb285ad35b1"
+CORE_COMMIT = "ad3ef3fb102bf393b9fe33ecb242848e5ca6b0df"
 
 
 def activate() -> None:

--- a/pretext/project/__init__.py
+++ b/pretext/project/__init__.py
@@ -754,18 +754,19 @@ class Target(pxml.BaseXmlModel, tag="target", search_mode=SearchMode.UNORDERED):
                     dest_dir=self.output_dir_abspath().as_posix(),
                     ext_rs_methods=utils.rs_methods,
                 )
-                try:
-                    codechat.map_path_to_xml_id(
-                        self.source_abspath(),
-                        self._project.abspath(),
-                        self.output_dir_abspath().as_posix(),
-                    )
-                except Exception as e:
-                    log.warning(
-                        "Failed to map codechat path to xml id; codechat will not work."
-                    )
-                    log.debug(f"Error: {e}")
-                    log.debug("Traceback:", exc_info=True)
+                if self.platform != Platform.RUNESTONE:
+                    # On non-runestone builds, we try to create a codechat mapping for authors.
+                    try:
+                        codechat.map_path_to_xml_id(
+                            self.source_abspath(),
+                            self._project.abspath(),
+                            self.output_dir_abspath().as_posix(),
+                        )
+                    except Exception as e:
+                        log.warning(
+                            "Failed to map codechat path to xml id; codechat will not work."
+                        )
+                        log.debug(e, exc_info=True)
             elif self.format == Format.PDF:
                 core.pdf(
                     xml=self.source_abspath(),


### PR DESCRIPTION
There should be no reason to create the codechat mapping for runestone platform builds.  This should disable that, and will fix the issue @rbeezer has building fcla on runestone.